### PR TITLE
Add fpm target as an option and other small changes.

### DIFF
--- a/bin/fpm-cook
+++ b/bin/fpm-cook
@@ -4,4 +4,4 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'fpm/cookery/cli'
 
-FPM::Cookery::CLI.new(ARGV).run
+FPM::Cookery::CLI.new.args(ARGV).run

--- a/lib/fpm/cookery/cli.rb
+++ b/lib/fpm/cookery/cli.rb
@@ -1,32 +1,90 @@
 require 'fpm/cookery/book_hook'
 require 'fpm/cookery/recipe'
 require 'fpm/cookery/packager'
+require 'optparse'
 
 module FPM
   module Cookery
     class CLI
-      def initialize(argv)
-        @argv = argv
+      def args(argv)
+        program = File.basename($0)
+        options = OptionParser.new
+        options.banner = \
+          "Usage: #{program} [options] [path/to/recipe.rb] action [...]"
+        options.separator "Actions:"
+        options.separator "  package - builds the package"
+        options.separator "  clean - cleans up"
+        options.separator "Options:"
+
+        options.on("-t TARGET", "--target TARGET",
+                  "Set the desired fpm output target (deb, rpm, etc)") do |o|
+          @target = o
+        end
+
+        # Parse flags and such, remainder is all non-option args.
+        remainder = options.parse(argv)
+
+        # Default recipe to find is in current directory named 'recipe.rb'
+        @filename = File.expand_path('recipe.rb')
+
+        # See if something that looks like a recipe path is in arguments
+        remainder.each do |arg|
+          # If 'foo.rb' was given, and it exists, use it.
+          if arg =~ /\.rb$/ and File.exists?(arg)
+            remainder.delete(arg)
+            @filename = arg
+            break
+          end
+
+          # Allow giving the directory containing a recipe.rb
+          if File.directory?(arg) and File.exists?(File.join(arg, "recipe.rb"))
+            remainder.delete(arg)
+            @filename = File.join(arg, "recipe.rb")
+            break
+          end
+        end
+
+        # Everything that's not the recipe filename is an action.
+        @actions = remainder
+        return self
       end
 
-      def run
-        filename = @argv.find {|arg| arg =~ /\.rb$/ and File.exists?(arg) }
-        filename ||= File.expand_path('recipe.rb')
-
-        unless File.exists?(filename)
+      def validate
+        unless File.exists?(@filename)
           STDERR.puts 'No recipe.rb found in the current directory, abort.'
           exit 1
         end
 
+        if @target.nil?
+          # TODO(sissel): Detect platform, try to guess @target?
+          @target = "deb"
+          puts "No --target given, assuming #{@target}"
+        end
+
+        # Default action is "package"
+        if @actions.empty?
+          @actions = ["package"]
+          puts "No actions given, assuming 'package'"
+        end
+      end
+
+      def run
+        validate
+
         FPM::Cookery::Recipe.send(:include, FPM::Cookery::BookHook)
 
-        FPM::Cookery::Book.load_recipe(filename) do |recipe|
+        FPM::Cookery::Book.load_recipe(@filename) do |recipe|
           packager = FPM::Cookery::Packager.new(recipe)
+          packager.target = @target
 
-          if @argv.include?('clean')
-            packager.cleanup
-          else
-            packager.dispense
+          @actions.each do |action|
+            case action
+            when "clean" ; packager.cleanup
+            when "package" ; packager.dispense
+            else
+              # TODO(sissel): fail if this happens
+              puts "Unknown action: #{action}"
+            end
           end
         end
       end

--- a/lib/fpm/cookery/packager.rb
+++ b/lib/fpm/cookery/packager.rb
@@ -16,7 +16,14 @@ module FPM
         @config = config
       end
 
+      def target=(target)
+        # TODO(sissel): do sanity checking
+        @target = target
+      end
+
       def cleanup
+        # TODO(sissel): do some sanity checking to make sure we don't
+        # accidentally rm -rf the wrong thing.
         FileUtils.rm_rf(recipe.builddir)
         FileUtils.rm_rf(recipe.destdir)
       end
@@ -115,10 +122,12 @@ Filename:          #{check.filename}
             "#{username} <#{useremail}>"
           end
 
+          # TODO(sissel): This should use an API in fpm. fpm doesn't have this
+          # yet.  fpm needs this.
           opts = [
             '-n', recipe.name,
             '-v', version,
-            '-t', 'deb',
+            '-t', @target,
             '-s', 'dir',
             '--url', recipe.homepage || recipe.url,
             '-C', recipe.destdir.to_s,


### PR DESCRIPTION
- Added '--target'/'-t' flags to fpm-cook and made necessary changes
  internally to allow telling the packager what fpm target to use.
- Allow being given a directory that includes a 'recipe.rb' as
  the thing to build. Previously required a full path to the
  recipe including the file itself
- Refactored the F::C::CLI class slightly to make args parsing easy.
- Added several TODOs in comments.
