### PR TITLE
Fixing for issue bernd/fpm-cookery#2

### DIFF
--- a/lib/fpm/cookery/packager.rb
+++ b/lib/fpm/cookery/packager.rb
@@ -147,6 +147,19 @@ Filename:          #{check.filename}
             '--architecture', recipe.arch.to_s
           ] if recipe.arch
 
+          script_map = {"preinst" => "--pre-install", "postinst" => "--post-install", "preun" => "--pre-uninstall", "postun" => "--post-uninstall"}
+          %w[preinst postinst preun postun].each do |script|
+            unless recipe.send(script).nil?
+              s = recipe.send(script)
+              if File.exists?("../#{s}")
+                p_opt = script_map[script]
+                opts += ["#{p_opt}", "../#{s}"]
+              else
+                raise "#{script} script '#{s}' is missing"
+              end
+            end
+          end
+
 #          if self.postinst
 #            postinst_file = Tempfile.open('postinst')
 #            postinst_file.puts(postinst)

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -44,7 +44,8 @@ module FPM
       end
 
       attr_rw :arch, :description, :homepage, :maintainer, :md5, :name,
-              :revision, :section, :sha1, :sha256, :spec, :vendor, :version
+              :revision, :section, :sha1, :sha256, :spec, :vendor, :version,
+              :preinst, :postinst, :preun, :postun
 
       attr_rw_list :build_depends, :config_files, :conflicts, :depends,
                    :exclude, :patches, :provides, :replaces

--- a/spec/recipe_spec.rb
+++ b/spec/recipe_spec.rb
@@ -75,6 +75,10 @@ describe "Recipe" do
   spec_recipe_attribute(:spec, {:foo => true})
   spec_recipe_attribute(:vendor, 'myvendor')
   spec_recipe_attribute(:version, '1.2')
+  spec_recipe_attribute(:preinst, 'preinstall')
+  spec_recipe_attribute(:postinst, 'postinstall')
+  spec_recipe_attribute(:preun, 'preuninstall')
+  spec_recipe_attribute(:postun, 'postuninstall')
 
   describe "#revision" do
     it "sets a default revision" do


### PR DESCRIPTION
Here's the pull request. Right now it's using attributes as opposed to methods. I waffled between being opinionated on it being a new boolean attribute and just looking for files called `preinst`, `postinst`, etc. vs. allowing explicit naming. I went with the explicit naming for flexibility.

One limitation is that the CLI is build to look in the parent of the build directory for the named scripts. This should probably leverage the path better.

I've tested this myself and you can see the `rpm -qp --scripts` output here:

```
[rpmbuild@localhost brisk]$ rpm -qp --scripts /home/rpmbuild/packages/recipes/brisk/pkg/cassandra-brisk-1.0_beta2+va0.noarch.rpm
preinstall scriptlet (using /bin/sh):
I should do something here before installing.
postinstall scriptlet (using /bin/sh):
I should do something here after installing
[rpmbuild@localhost brisk]$
```
