### PR TITLE
add gem source handler

### DIFF
--- a/lib/fpm/cookery/source_handler.rb
+++ b/lib/fpm/cookery/source_handler.rb
@@ -3,6 +3,7 @@ require 'fpm/cookery/source_handler/curl'
 require 'fpm/cookery/source_handler/svn'
 require 'fpm/cookery/source_handler/git'
 require 'fpm/cookery/source_handler/hg'
+require 'fpm/cookery/source_handler/gem'
 require 'fpm/cookery/log'
 
 module FPM

--- a/lib/fpm/cookery/source_handler/gem.rb
+++ b/lib/fpm/cookery/source_handler/gem.rb
@@ -1,0 +1,38 @@
+require 'fpm/cookery/source_handler/template'
+require 'fpm/cookery/log'
+
+module FPM
+  module Cookery
+    class SourceHandler
+      class Gem < FPM::Cookery::SourceHandler::Template
+        NAME = :gem
+        CHECKSUM = true
+
+        def fetch
+          name = options[:name]
+          version = options[:version]
+
+          if local_path.exist?
+            Log.info "Using cached file #{local_path}"
+          else
+            Dir.chdir(cachedir) do
+              gem(name, version, url) unless local_path.exist?
+            end
+          end
+          
+          local_path
+        end
+
+        def extract
+          FileUtils.cp(local_path, '.')
+          Dir.pwd
+        end
+
+        private
+        def gem(name, version, source)
+          safesystem('gem', 'fetch', name, '-v', version, '--source', source)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I just started using fpm-cookery and would like a uniform interface to building packages. Since I use fpm to build Ruby gems, I hacked this branch together.

I don't know if this is of any value to you. Here's an example recipe:

```
class RubygemJson173 < FPM::Cookery::Recipe
  description 'This is a JSON implementation as a Ruby extension in C.'

  name 'rubygem-json'
  version '1:1.7.3'
  revision 1
  homepage 'http://www.rubygems.org/'
  source 'http://rubygems.org', :with => :gem, :name => 'json', :version => '1.7.3', :as => 'json-1.7.3.gem'
  sha256 '1070e6cd2fedc0cb06e7e56a980b884bdf6e61a9184abb1c6e677d308b4c26d9'

  section 'ruby'

  def build
    # noop
  end

  def install
    system "gem install --ignore-dependencies --no-rdoc --no-ri --bindir #{destdir}/usr/bin --install-dir=#{destdir}/usr/lib/ruby/gems/1.8 json-1.7.3.gem"
  end
end
```
