### PR TITLE
unbust rpm creation on rhel5 due to undue obsession with xz compression

### DIFF
--- a/lib/fpm/cookery/packager.rb
+++ b/lib/fpm/cookery/packager.rb
@@ -170,6 +170,11 @@ module FPM
           input.attributes[:prefix] = '/'
           input.attributes[:chdir] = recipe.destdir.to_s
           input.attributes[:excludes] = [] # TODO replace remove_excluded_files() with this
+          input.attributes[:rpm_compression] = "gzip"
+          input.attributes[:rpm_digest] = "md5"
+          input.attributes[:rpm_user] = "root"
+          input.attributes[:rpm_group] = "root"
+
           input.input('.')
 
           output_class = FPM::Package.types[@target]


### PR DESCRIPTION
see this::
https://github.com/jordansissel/fpm/issues/192

you may choose to fix more elegantly but gz/md5 for all are good enough for my purposes.

apologies for using rhel5, its not my fault..

thanks for creating this handy program!
