### PR TITLE
add support for shar and "bin" files to curl source handler

### DIFF
--- a/lib/fpm/cookery/source_handler/curl.rb
+++ b/lib/fpm/cookery/source_handler/curl.rb
@@ -25,6 +25,9 @@ module FPM
             case local_path.extname
             when '.bz2', '.gz', '.tgz'
               safesystem('tar', 'xf', local_path)
+            when '.shar', '.bin'
+              File.chmod(0755, local_path)
+              safesystem(local_path)
             when '.zip'
               safesystem('unzip', '-d', local_path.basename('.zip'), local_path)
             end


### PR DESCRIPTION
mainly just for oracle and their silly jdk licensing..  should also work for other 3rd party software with funny packaging..
