### PR TITLE
ensure we send over the vendor attribute to fpm so it is set in the package control file

### DIFF
--- a/lib/fpm/cookery/packager.rb
+++ b/lib/fpm/cookery/packager.rb
@@ -151,6 +151,7 @@ module FPM
 
           input.version = version
           input.maintainer = maintainer
+          input.vendor = vendor if vendor
           input.epoch = epoch if epoch
 
           add_scripts(recipe, input)


### PR DESCRIPTION
When creating a DEB on Ubuntu, the resulting package's control file had the _Vendor_ attribute not set correctly.
This is only tested with DEB files.
