### PR TITLE
Add support for an :args option with the curl handler

### DIFF
--- a/lib/fpm/cookery/source_handler/curl.rb
+++ b/lib/fpm/cookery/source_handler/curl.rb
@@ -43,7 +43,8 @@ module FPM
 
         private
         def curl(url, path)
-          safesystem('curl', '-fL', '--progress-bar', '-o', path, url)
+          args = options[:args] || ['-fL']
+          safesystem('curl', args, '--progress-bar', '-o', path, url)
         end
 
         def extracted_source


### PR DESCRIPTION
This allows the overriding of the arguments sent to curl, so that one
can use custom certificates, disable redirection, etc. The default is
the old static behavior.

Example:

```
source 'https://registry.npmjs.org/hubot/-/hubot-2.5.1.tgz', :with => :curl, :args => '-fkL'
```
