### PR TITLE
switch from ruby URI to Addressable::URI

### DIFF
--- a/fpm-cookery.gemspec
+++ b/fpm-cookery.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "fpm", "~> 0.4"
   s.add_runtime_dependency "facter"
   s.add_runtime_dependency "puppet"
+  s.add_runtime_dependency "addressable"
 end

--- a/lib/fpm/cookery/source.rb
+++ b/lib/fpm/cookery/source.rb
@@ -1,4 +1,4 @@
-require 'uri'
+require 'addressable/uri'
 
 module FPM
   module Cookery
@@ -7,8 +7,7 @@ module FPM
 
       def initialize(url, options = nil)
         options ||= {}
-
-        @url = URI(url.to_s)
+        @url = Addressable::URI.parse(url.to_s)
         @provider = options[:with]
         @options = options
       end


### PR DESCRIPTION
When the source was a private github repos ruby 1.9's URI was borking with a not a URI error.

``` bash
lunix@madeira]  (master) -> be fpm-cook
DEBUG: url = git@github.com:foo/bar.git
/home/lunix/.rbenv/versions/1.9.3-p125/lib/ruby/1.9.1/uri/common.rb:176:in `split': bad URI(is not URI?): git@github.com:foo/bar.git (URI::InvalidURIError)
    from /home/lunix/.rbenv/versions/1.9.3-p125/lib/ruby/1.9.1/uri/common.rb:211:in `parse'
    from /home/lunix/.rbenv/versions/1.9.3-p125/lib/ruby/1.9.1/uri/common.rb:747:in `parse'
    from /home/lunix/.rbenv/versions/1.9.3-p125/lib/ruby/1.9.1/uri/common.rb:994:in `URI'
    from /home/lunix/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/fpm-cookery-0.14.0/lib/fpm/cookery/source.rb:16:in `initialize'
    from /home/lunix/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/fpm-cookery-0.14.0/lib/fpm/cookery/recipe.rb:84:in `new'
    from /home/lunix/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/fpm-cookery-0.14.0/lib/fpm/cookery/recipe.rb:84:in `initialize'
    from /home/lunix/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/fpm-cookery-0.14.0/lib/fpm/cookery/book.rb:16:in `new'
    from /home/lunix/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/fpm-cookery-0.14.0/lib/fpm/cookery/book.rb:16:in `load_recipe'
    from /home/lunix/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/fpm-cookery-0.14.0/lib/fpm/cookery/cli.rb:125:in `run'
    from /home/lunix/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/fpm-cookery-0.14.0/bin/fpm-cook:7:in `<top (required)>'
    from /home/lunix/.rbenv/versions/1.9.3-p125/bin/fpm-cook:23:in `load'
    from /home/lunix/.rbenv/versions/1.9.3-p125/bin/fpm-cook:23:in `<main>'
```

[sporkmonger/addressable](https://github.com/sporkmonger/addressable) solves this issue.
I have not tested this extensively yet with other source types but hope to have some time later tonight.
