### PR TITLE
Chain packager

### DIFF
--- a/lib/fpm/cookery/chain_packager.rb
+++ b/lib/fpm/cookery/chain_packager.rb
@@ -1,0 +1,58 @@
+require 'fpm/cookery/packager'
+require 'fpm/cookery/omnibus_packager'
+
+module FPM
+  module Cookery
+    class ChainPackager
+      include FPM::Cookery::Utils
+
+      attr_reader :packager, :recipe, :config
+
+      def initialize(packager, config = {})
+        @packager = packager
+        @recipe = packager.recipe
+        @config = config
+      end
+
+      def run
+        Log.info "Recipe #{recipe.name} is a chain package; looking for child recipes to build"
+
+        recipe.chain_recipes.each do |name|
+          recipe_file = build_recipe_file_path(name)
+
+          unless File.exists?(recipe_file)
+            Log.fatal "Cannot find a recipe for #{name} at #{recipe_file}"
+            exit 1
+          end
+
+          Log.info "Located recipe at #{recipe_file} for child recipe #{name}; starting build"
+
+          FPM::Cookery::Book.instance.load_recipe(recipe_file) do |dep_recipe|
+            depPackager = FPM::Cookery::Packager.new(dep_recipe, config)
+            depPackager.target = FPM::Cookery::Facts.target.to_s
+
+            #Chain, chain, chain ...
+            if dep_recipe.omnibus_package == true
+              FPM::Cookery::OmnibusPackager.new(depPackager, config).run
+            elsif dep_recipe.chain_package == true
+              FPM::Cookery::ChainPackager.new(depPackager, config).run
+            else
+              depPackager.dispense
+            end
+          end
+
+          Log.info "Finished building #{name}, moving on to next recipe"
+        end
+
+        packager.dispense
+      end
+
+      private
+
+      def build_recipe_file_path(name)
+        # Look for recipes in the same dir as the recipe we loaded
+        File.expand_path(File.dirname(recipe.filename) + "/#{name}.rb")
+      end
+    end
+  end
+end

--- a/lib/fpm/cookery/cli.rb
+++ b/lib/fpm/cookery/cli.rb
@@ -2,6 +2,7 @@ require 'fpm/cookery/book_hook'
 require 'fpm/cookery/recipe'
 require 'fpm/cookery/facts'
 require 'fpm/cookery/packager'
+require 'fpm/cookery/chain_packager'
 require 'fpm/cookery/omnibus_packager'
 require 'fpm/cookery/log'
 require 'fpm/cookery/log/output/console'
@@ -136,6 +137,8 @@ module FPM
             when "package"
               if recipe.omnibus_package == true
                 FPM::Cookery::OmnibusPackager.new(packager).run
+              elsif recipe.chain_package == true
+                FPM::Cookery::ChainPackager.new(packager, :dependency_check => !@nodep).run
               else
                 packager.dispense
               end

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -56,11 +56,11 @@ module FPM
       attr_rw :arch, :description, :homepage, :maintainer, :md5, :name,
               :revision, :section, :sha1, :sha256, :spec, :vendor, :version,
               :pre_install, :post_install, :pre_uninstall, :post_uninstall,
-              :license, :omnibus_package, :omnibus_dir
+              :license, :omnibus_package, :omnibus_dir, :chain_package
 
       attr_rw_list :build_depends, :config_files, :conflicts, :depends,
                    :exclude, :patches, :provides, :replaces, :omnibus_recipes,
-                   :omnibus_additional_paths
+                   :omnibus_additional_paths, :chain_recipes
 
       class << self
         def source(source = nil, spec = {})

--- a/spec/recipe_spec.rb
+++ b/spec/recipe_spec.rb
@@ -176,6 +176,12 @@ describe "Recipe" do
     end
   end
 
+  describe "#chain_package" do
+    it "can be set" do
+      check_attribute(:chain_package, true)
+    end
+  end
+
   describe "#omnibus_package" do
     it "can be set" do
       check_attribute(:omnibus_package, true)
@@ -216,6 +222,7 @@ describe "Recipe" do
   spec_recipe_attribute_list(:provides, %w{one two})
   spec_recipe_attribute_list(:replaces, %w{one two})
   spec_recipe_attribute_list(:omnibus_recipes, %w{one two})
+  spec_recipe_attribute_list(:chain_recipes, %w{one two})
 
   describe ".source" do
     it "sets a source url" do


### PR DESCRIPTION
Not quite happy with the concept of the Omnibus packager here's a ChainPackager (feel free to rename it).

Instead of creating a fat package with all dependencies, this one recursively parses recipes and create a package per recipe.

In case you're considering merging this, merge it before #18. I'll rebase it against this branch and use the chain packager in the fpm-cookery-gem recipe.
