### PR TITLE
More fine-grained search for Ruby-libs to strip

### DIFF
--- a/recipes/fpm-cookery/ruby.rb
+++ b/recipes/fpm-cookery/ruby.rb
@@ -32,6 +32,6 @@ class Ruby200 < FPM::Cookery::Recipe
     # Shrink package.
     rm_f "#{destdir}/lib/libruby-static.a"
     safesystem "strip #{destdir}/bin/ruby"
-    safesystem "find #{destdir} -name '*.so*' | xargs strip"
+    safesystem "find #{destdir} -name '*.so' -or -name '*.so.*' | xargs strip"
   end
 end


### PR DESCRIPTION
This prevents the xargs strip command from exiting on puppet-3.2.2/ext/debian/README.source
