### PR TITLE
compatibility fix with fpm path-mapping feature

### DIFF
--- a/lib/fpm/cookery/path.rb
+++ b/lib/fpm/cookery/path.rb
@@ -21,6 +21,10 @@ module FPM
         self + (path || '').gsub(%r{^/}, '')
       end
 
+      def =~(regex)
+        @path =~ regex
+      end
+
       def mkdir
         FileUtils.mkdir_p(self.to_s)
       end


### PR DESCRIPTION
FPM::Package::Dir expects paths to behave as strings.
The [path-mapping](https://github.com/jordansissel/fpm/commit/8360506c394b18e568d17b66e650639b46fbae7b) feature depends on regex comparisons with
path names.

Check the [error the PR addresses and a minimal recipe to reproduce](https://gist.github.com/skiold/f6b9da6664fc1c0067f4)
