### PR TITLE
Add CLI option to disable default vendor

### DIFF
--- a/lib/fpm/cookery/packager.rb
+++ b/lib/fpm/cookery/packager.rb
@@ -148,7 +148,7 @@ module FPM
           end
 
           # Build a version including vendor and revision.
-          vendor = config[:vendor] || recipe.vendor
+          vendor = config[:vendor] || recipe.vendor || config[:use_default_vendor] ? "fpm" : nil
           vendor_rev = "#{vendor}#{recipe.revision}"
           case @target
           when "deb"
@@ -158,7 +158,6 @@ module FPM
           else
             vendor_delimiter = "-"
           end
-          version = [ver, vendor_rev].join(vendor_delimiter)
 
           maintainer = recipe.maintainer || begin
             username = git_config('user.name')
@@ -169,7 +168,7 @@ module FPM
 
           input = recipe.input
 
-          input.version = version
+          input.version = vendor ? [ver, vendor_rev].join(vendor_delimiter) : ver
           input.maintainer = maintainer
           input.vendor = vendor if vendor
           input.epoch = epoch if epoch

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -80,7 +80,6 @@ module FPM
         @filename = Path.new(filename).expand_path
 
         # Set some defaults.
-        vendor || self.class.vendor('fpm')
         revision || self.class.revision(0)
       end
 


### PR DESCRIPTION
As I'm still unable to install debs generated with '+fpm0' stensa I've added a '--no-default-vendor' CLI option to disable the use of fpm as vendor if none is provided. This uses code reverted in d529051e0d88fab0c4ddbcd36b53ced916561781 in case the option is used and otherwise behaves as current master does.

I'm happy to add more commits to implement any suggestion or fix any regression (there seems to be an obvious one with regards to default revision too). Looking forward to discuss this further (if needed).
