### PR TITLE
Ability to set full prefix w/o /usr

### DIFF
--- a/lib/fpm/cookery/path_helper.rb
+++ b/lib/fpm/cookery/path_helper.rb
@@ -30,6 +30,10 @@ module FPM
         current_pathname_for('var')/path
       end
 
+      def root_prefix(path = nil)
+        current_pathname_for(nil)/path
+      end
+
       def bin(path = nil)     prefix/'bin'/path            end
       def doc(path = nil)     prefix/'share/doc'/path      end
       def include(path = nil) prefix/'include'/path        end


### PR DESCRIPTION
Greetings,

I was attempting to build some RPM packages and set the fpm --prefix value to /mochi/lib/flex_sdk/

I found out that the prefix definition always appends /usr to the beginning of the prefix option.  I think it would be useful to be able to set the full prefix path starting at root '/'

Worked well with recipe:

```
class Flex46 < FPM::Cookery::Recipe
  description 'Adobe Flex SDK'

  name     'flex_sdk'
  version  '4.6'
  homepage 'http://www.adobe.com/devnet/flex.html'
  source   'http://download.macromedia.com/pub/flex/sdk/flex_sdk_4.6.zip'
  sha256   '622b63f29de44600ff8d4231174a70fcb3085812c0e146a42e91877ca8b46798'
  section 'main'

  depends       'java-1.6.0-openjdk', 'java-1.6.0-openjdk-devel'

  post_install 'post-install'

  def build
  rm_f Dir['runtimes/air/mac/Adobe\ AIR.framework/Adobe\ AIR'], :verbose => true
  rm_f Dir['runtimes/air/mac/Adobe\ AIR.framework/Headers'], :verbose => true
  rm_f Dir['runtimes/air/mac/Adobe\ AIR.framework/Resources'], :verbose => true
  rm_f Dir['runtimes/air/mac/Adobe\ AIR.framework/Versions/Current'], :verbose => true
  rm_f Dir['runtimes/air-captive/mac/Adobe\ AIR.framework/Adobe\ AIR'], :verbose => true
  rm_f Dir['runtimes/air-captive/mac/Adobe\ AIR.framework/Resources'], :verbose => true
  rm_f Dir['runtimes/air-captive/mac/Adobe\ AIR.framework/Versions/Current'], :verbose => true
  end

  def install
  root_prefix("/mochi/lib/#{name}_#{version}").install Dir['*']
  end

end
```

If you think this root_prefix option is a good idea to merge in, I can write a spec test before merge if you want.
