### PR TITLE
adding autogen support

### DIFF
--- a/lib/fpm/cookery/utils.rb
+++ b/lib/fpm/cookery/utils.rb
@@ -21,7 +21,7 @@ module FPM
       end
 
       # From brew2deb. (lib/debian_formula.rb)
-      def configure(*args)
+      def argument_build(*args)
         if args.last.is_a?(Hash)
           opts = args.pop
           args += opts.map{ |k,v|
@@ -33,25 +33,17 @@ module FPM
             end
           }
         end
+      end
 
+      def configure(*args)
+        args = argument_build(*args)
         safesystem './configure', *args
       end
-      
-      def autogen(*args)
-        if args.last.is_a?(Hash)
-          opts = args.pop
-          args += opts.map{ |k,v|
-            option = k.to_s.gsub('_','-')
-            if v == true
-              "--#{option}"
-            else
-              "--#{option}=#{v}"
-            end
-          }
-        end
 
-        safesystem './autogen.sh', *args
-      end
+     def autogen(*args)
+       args =  argument_build(*args)
+       safesystem './autogen.sh', *args
+     end
 
       # From brew2deb. (lib/debian_formula.rb)
       def make(*args)


### PR DESCRIPTION
I needed to add this for builds that use autogen (http://inti.sourceforge.net/tutorial/libinti/autotoolsproject.html) to run configuration steps.  For example, Mono.

My recipe:

```
class Mono < FPM::Cookery::Recipe
  description 'Mono open source ECMA CLI, C# and .NET implementation.'

  name     'mono'
  version  "3.2.4-branch"
  homepage 'http://www.mono-project.com'
  source   'https://github.com/mono/mono', :submodule => ["external/ikvm", "external/Newtonsoft.Json", "external/aspnetwebstack", "external/cecil"], :with => :git, :branch => "mono-3.2.4-branch"
  section 'main'

  build_depends 'gettext', 'libtool', 'automake', 'make', 'gcc', 'autoconf'

  def build
    autogen :prefix => "/usr/local",
            :enable_parallel_mark => true

    make 'get-monolite-latest'

    make 'EXTERNAL_MCS' => "#{Dir.pwd}/mcs/class/lib/monolite/gmcs.exe"
  end

  def install
    make :install, 'DESTDIR' => destdir
  end

end
```
