### PR TITLE
more explicit message for when a build cookie is found

### DIFF
--- a/lib/fpm/cookery/packager.rb
+++ b/lib/fpm/cookery/packager.rb
@@ -107,7 +107,8 @@ module FPM
               build_cookie = build_cookie_name(package_name)
 
               if File.exists?(build_cookie)
-                Log.info 'Skipping build (`fpm-cook clean` to rebuild)'
+                Log.warn "Skipping build of #{recipe.name} because build cookie found (#{build_cookie})," \
+                         " use \"fpm-cook clean\" to rebuild!"
               else
                 Log.info "Building in #{File.expand_path(extracted_source, recipe.builddir)}"
                 recipe.build and FileUtils.touch(build_cookie)


### PR DESCRIPTION
Hey mate, a build of ours died half way through and the build cookie was left hanging around but the old message was a little hard to see in all the output. Hopefully this makes things stand out a bit more.

Thanks you,

Pauly
