### PR TITLE
Add support for 'npm'

### DIFF
--- a/lib/fpm/cookery/package/npm.rb
+++ b/lib/fpm/cookery/package/npm.rb
@@ -1,0 +1,22 @@
+require 'fpm/package/npm'
+require 'fpm/cookery/package/package'
+
+module FPM
+  module Cookery
+    module Package
+      class NPM < FPM::Cookery::Package::Package
+        def fpm_object
+          FPM::Package::NPM.new
+        end
+
+        def package_setup
+          fpm.version = recipe.version
+        end
+
+        def package_input
+          fpm.input(recipe.name)
+        end
+      end
+    end
+  end
+end

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -7,6 +7,7 @@ require 'fpm/cookery/utils'
 require 'fpm/cookery/path_helper'
 require 'fpm/cookery/package/dir'
 require 'fpm/cookery/package/gem'
+require 'fpm/cookery/package/npm'
 
 module FPM
   module Cookery
@@ -143,6 +144,12 @@ module FPM
     class RubyGemRecipe < BaseRecipe
       def input(config)
         FPM::Cookery::Package::Gem.new(self, config)
+      end
+    end
+
+    class NPMRecipe < BaseRecipe
+      def input(config)
+        FPM::Cookery::Package::NPM.new(self, config)
       end
     end
   end


### PR DESCRIPTION
Moin,

this adds support for building npm packages.
Simple recipe would look like this:

``` ruby
class Less < FPM::Cookery::NPMRecipe
  description 'Less - leaner css'

  name     'less'
  version  '1.6.3'
  depends  'nodejs'
end
```

Cheers,
Jan

PS: Thanks to @mlafeldt.
