### PR TITLE
Initial spike for pleaserun support

### DIFF
--- a/fpm-cookery.gemspec
+++ b/fpm-cookery.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "puppet"
   s.add_runtime_dependency "addressable"
   s.add_runtime_dependency "systemu"
+  s.add_runtime_dependency "pleaserun"
 end

--- a/lib/fpm/cookery/packager.rb
+++ b/lib/fpm/cookery/packager.rb
@@ -121,6 +121,11 @@ module FPM
                 recipe.installing = true
                 Log.info "Installing into #{recipe.destdir}"
                 recipe.install
+
+                # Write startup scripts.
+                recipe.startup_scripts.each do |script|
+                  script.write_to(recipe.destdir)
+                end
               ensure
                 recipe.installing = false
               end

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -8,6 +8,8 @@ require 'fpm/cookery/path_helper'
 require 'fpm/cookery/package/dir'
 require 'fpm/cookery/package/gem'
 require 'fpm/cookery/package/npm'
+require 'fpm/cookery/startup_script'
+require 'fpm/cookery/log'
 
 module FPM
   module Cookery
@@ -36,6 +38,31 @@ module FPM
 
       def self.architectures(archs)
         Array(archs).member?(FPM::Cookery::Facts.arch) and block_given? ? yield : false
+      end
+
+      def self.startup_script(program, options = {})
+        script = FPM::Cookery::StartupScript.new
+
+        options.merge(:program => program).each do |key, value|
+          next if value.to_s.empty?
+
+          begin
+            script.__send__("#{key}=", value)
+          rescue NoMethodError
+            Log.warn(%(Invalid startup script option "#{key}"!))
+          end
+        end
+
+        @startup_scripts ||= []
+        @startup_scripts << script
+      end
+
+      def self.startup_scripts
+        @startup_scripts
+      end
+
+      def startup_scripts
+        self.class.startup_scripts
       end
 
       def self.attr_rw_list(*attrs)

--- a/lib/fpm/cookery/startup_script.rb
+++ b/lib/fpm/cookery/startup_script.rb
@@ -1,0 +1,50 @@
+require 'pleaserun/namespace'
+require 'pleaserun/detector'
+
+module FPM
+  module Cookery
+    class StartupScript
+      attr_accessor :program, :name, :args, :user, :group, :description,
+                    :chdir, :umask, :prestart
+
+      def initialize
+        @platform, @target_version = PleaseRun::Detector.detect
+
+        require "pleaserun/platform/#{@platform}"
+        const = PleaseRun::Platform.constants.find { |c| c.to_s.downcase == @platform.downcase }
+
+        @platform_class = PleaseRun::Platform.const_get(const)
+        @runner = @platform_class.new(@target_version)
+      end
+
+      def write_to(root)
+        ensure_attributes!
+
+        @runner.files.each do |path, content, perms|
+          fullpath = root + path.gsub(%r(^/+), '')
+
+          FileUtils.mkdir_p(File.dirname(fullpath))
+          File.open(fullpath, 'w') {|f| f.write(content) }
+          File.chmod(perms, fullpath) if perms
+        end
+
+        # TODO Check how to install action scripts. pre/post script?
+        #PleaseRun::Installer.write_actions(@runner, ...)
+      end
+
+      private
+
+      def ensure_attributes!
+        @runner.program = program
+        @runner.name = name || File.basename(program)
+        @runner.args = args.split(/\s+/) if args
+        @runner.user = user if user
+        @runner.group = group if group
+        @runner.description = description if description
+        @runner.chdir = chdir if chdir
+        @runner.umask = umask if umask
+        @runner.prestart = prestart if prestart
+      end
+    end
+  end
+end


### PR DESCRIPTION
I experimented with [pleaserun](https://github.com/jordansissel/pleaserun) support for fpm-cookery.

Example:

``` ruby
class Redis < FPM::Cookery::Recipe
  # ...

  # Creates first startup script for redis-server binary with default settings
  startup_script '/usr/bin/redis-server'

  # Creates a second one
  startup_script '/usr/bin/redis-server',
                 :name => 'redis2',
                 :args => '--port 1234',
                 :description => 'Second Redis instance',
                 :user => 'nobody',
                 :group => 'nobody'

  # startup_script options: :name, :args, :user, :group, :description, :chdir, :umask, :prestart
  # ...
end
```

Looking for feedback on the API! :) /cc @beddari @jordansissel
