### PR TITLE
Add support for pypi packages

### DIFF
--- a/lib/fpm/cookery/package/python.rb
+++ b/lib/fpm/cookery/package/python.rb
@@ -1,0 +1,22 @@
+require 'fpm/package/python'
+require 'fpm/cookery/package/package'
+
+module FPM
+  module Cookery
+    module Package
+      class Python < FPM::Cookery::Package::Package
+        def fpm_object
+          FPM::Package::Python.new
+        end
+
+        def package_setup
+          fpm.version = recipe.version
+        end
+
+        def package_input
+          fpm.input(recipe.pypi_name || recipe.name)
+        end
+      end
+    end
+  end
+end

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -8,6 +8,7 @@ require 'fpm/cookery/path_helper'
 require 'fpm/cookery/package/dir'
 require 'fpm/cookery/package/gem'
 require 'fpm/cookery/package/npm'
+require 'fpm/cookery/package/python'
 
 module FPM
   module Cookery
@@ -159,6 +160,13 @@ module FPM
     class NPMRecipe < BaseRecipe
       def input(config)
         FPM::Cookery::Package::NPM.new(self, config)
+      end
+    end
+
+    class PythonRecipe < BaseRecipe
+      attr_rw :pypi_name
+      def input(config)
+        FPM::Cookery::Package::Python.new(self, config)
       end
     end
   end

--- a/recipes/python-requests/recipe.rb
+++ b/recipes/python-requests/recipe.rb
@@ -1,0 +1,8 @@
+class PythonRequests < FPM::Cookery::PythonRecipe
+  homepage "http://python-requests.org"
+  pypi_name "requests"
+  name "python-requests"
+  build_depends ["python-setuptools"]
+  depends ["python"]
+  version "2.2.1"
+end


### PR DESCRIPTION
We added recipe.pypi_name in order to allow the package name differ from pypi name.
