### PR TITLE
Add support for PEAR packages

### DIFF
--- a/lib/fpm/cookery/package/pear.rb
+++ b/lib/fpm/cookery/package/pear.rb
@@ -11,14 +11,9 @@ module FPM
 
         def package_setup
           fpm.version = recipe.version
-
-          fpm.attributes[:prefix]                   = recipe.prefix unless recipe.prefix.nil?
+          # Other attributes may be passed via fpm_attributes
           fpm.attributes[:pear_package_name_prefix] = recipe.pear_package_name_prefix unless recipe.pear_package_name_prefix.nil?
           fpm.attributes[:pear_channel]             = recipe.pear_channel unless recipe.pear_channel.nil?
-          fpm.attributes[:pear_channel_update?]     = recipe.pear_channel_update unless recipe.pear_channel_update.nil?
-          fpm.attributes[:pear_bin_dir]             = recipe.pear_bin_dir unless recipe.pear_bin_dir.nil?
-          fpm.attributes[:pear_data_dir]            = recipe.pear_data_dir unless recipe.pear_data_dir.nil?
-          fpm.attributes[:pear_php_bin]             = recipe.pear_php_bin unless recipe.pear_php_bin.nil?
           fpm.attributes[:pear_php_dir]             = recipe.pear_php_dir unless recipe.pear_php_dir.nil?
         end
 

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -187,9 +187,7 @@ module FPM
     end
 
     class PEARRecipe < BaseRecipe
-      attr_rw :prefix, :pear_package_name_prefix
-      attr_rw :pear_channel, :pear_channel_update
-      attr_rw :pear_bin_dir, :pear_data_dir, :pear_php_bin, :pear_php_dir
+      attr_rw :pear_package_name_prefix, :pear_channel, :pear_php_dir
 
       def input(config)
         FPM::Cookery::Package::PEAR.new(self, config)


### PR DESCRIPTION
Note on the attributes: With this PR, all attributes supported by FPM can be passed via an fpm-cookery recipe. I'm not sure if this flexibility is required or how attributes are normally handled (they're missing in most other package types).
