### PR TITLE
Add support for CPAN packages

### DIFF
--- a/lib/fpm/cookery/package/cpan.rb
+++ b/lib/fpm/cookery/package/cpan.rb
@@ -1,0 +1,23 @@
+require 'fpm/package/cpan'
+require 'fpm/cookery/package/package'
+
+module FPM
+  module Cookery
+    module Package
+      class CPAN < FPM::Cookery::Package::Package
+        def fpm_object
+          FPM::Package::CPAN.new
+        end
+
+        def package_setup
+          # Other attributes may be passed via fpm_attributes
+          fpm.version = recipe.version
+        end
+
+        def package_input
+          fpm.input(recipe.name)
+        end
+      end
+    end
+  end
+end

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -5,6 +5,7 @@ require 'fpm/cookery/source'
 require 'fpm/cookery/source_handler'
 require 'fpm/cookery/utils'
 require 'fpm/cookery/path_helper'
+require 'fpm/cookery/package/cpan'
 require 'fpm/cookery/package/dir'
 require 'fpm/cookery/package/gem'
 require 'fpm/cookery/package/npm'
@@ -182,6 +183,12 @@ module FPM
     class PythonRecipe < BaseRecipe
       def input(config)
         FPM::Cookery::Package::Python.new(self, config)
+      end
+    end
+
+    class CPANRecipe < BaseRecipe
+      def input(config)
+        FPM::Cookery::Package::CPAN.new(self, config)
       end
     end
   end


### PR DESCRIPTION
Example recipe:

``` ruby
class PerlLinguaJARomanizeJapanese < FPM::Cookery::CPANRecipe
  name       "Lingua::JA::Romanize::Japanese"
  version    "0.23"
  maintainer "Mathias Lafeldt <mathias.lafeldt@jimdo.com>"

  build_depends "liblocal-lib-perl"
  depends       "perl"

  fpm_attributes :no_auto_depends?   => true,
                 :cpan_perl_lib_path => "/usr/share/perl5",
                 :cpan_mirror        => "http://artfiles.org/cpan.org/"
end
```

Note that I decided to use the new `fpm_attributes` helper to pass any attributes to FPM instead of implementing them in `FPM::Cookery::Package::CPAN`. Not sure what's the preferred way here though.
