### PR TITLE
add python_package_prefix

### DIFF
--- a/lib/fpm/cookery/package/python.rb
+++ b/lib/fpm/cookery/package/python.rb
@@ -12,6 +12,7 @@ module FPM
         def package_setup
           fpm.version = recipe.version
 
+          fpm.attributes[:python_package_prefix] = recipe.python_package_prefix
           fpm.attributes[:python_fix_name?] = true
           fpm.attributes[:python_fix_dependencies?] = true
         end

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -190,6 +190,7 @@ module FPM
     end
 
     class PythonRecipe < BaseRecipe
+      attr_rw :python_package_prefix
       def input(config)
         FPM::Cookery::Package::Python.new(self, config)
       end


### PR DESCRIPTION
This expose the package-name-prefix option of fpm, 
  see: https://github.com/jordansissel/fpm/wiki/ConvertingPython
`Usecase:` prefix for a different python version
