### PR TITLE
Avoid using git ls-files in gemspec

### DIFF
--- a/fpm-cookery.gemspec
+++ b/fpm-cookery.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "fpm-cookery"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = Dir['**/*']
+  s.test_files    = Dir['{test,spec,features}/**/*']
+  s.executables   = Dir['bin/*'].map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
git might not always be available when installing from source

References:
rodjek/rspec-puppet#111
bundler/bundler#2287
