### PR TITLE
fixed excludes.

### DIFF
--- a/lib/fpm/cookery/packager.rb
+++ b/lib/fpm/cookery/packager.rb
@@ -160,6 +160,7 @@ module FPM
 
           output_class = FPM::Package.types[@target]
 
+          input.fpm.attributes[:excludes] = recipe.exclude
           output = input.convert(output_class)
 
           begin


### PR DESCRIPTION
It seems exclude array is not passed into the FPM, so the produced package does contain files which should be excluded. I did this change to pass them into input.fpm.attributes[:excludes]. Not sure if it's correct though. Please review if this makes sense.