### PR TITLE
Allow specification of recipe attributes in (templated) YAML file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmp-dest/
 .vagrant
 Vagrantfile
 /vendor
+Makefile

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+GEMSPEC=$(shell echo *.gemspec | awk '{print $$1}')
+VERSION=$(shell awk -F\' '/VERSION =/ { print $$2 }' lib/fpm/cookery/version.rb)
+NAME=$(shell awk -F\" '/s.name/ { print $$2 }' $(GEMSPEC))
+GEM=$(NAME)-$(VERSION).gem
+
+.PHONY: build
+build: $(GEM)
+
+.PHONY: test
+test:
+	rm -rf .yardoc
+	rspec
+	#sh notify-failure.sh rspec
+
+.PHONY: testloop
+testloop:
+	while true; do \
+		$(MAKE) test; \
+		$(MAKE) wait-for-changes; \
+	done
+
+.PHONY: serve-coverage
+serve-coverage:
+	cd coverage; python -mSimpleHTTPServer
+
+.PHONY: wait-for-changes
+wait-for-changes:
+	-inotifywait --exclude '\.swp' -e modify $$(find $(DIRS) -name '*.rb'; find $(DIRS) -type d)
+
+.PHONY: package
+package: | $(GEM)
+
+.PHONY: gem
+gem: $(GEM)
+
+$(GEM):
+	gem build $(GEMSPEC)
+
+.PHONY: test-package
+test-package: $(GEM)
+	# Sometimes 'gem build' makes a faulty gem.
+	gem unpack $(GEM)
+	rm -rf ftw-$(VERSION)/
+
+.PHONY: publish
+publish: test-package
+	gem push $(GEM)
+
+.PHONY: install
+install: $(GEM)
+	gem install $(GEM)
+
+.PHONY:
+clean:
+	rm -rf package-*/ *.rpm *.deb *.gz *.tar *.gem .yardoc/

--- a/lib/fpm/cookery/book.rb
+++ b/lib/fpm/cookery/book.rb
@@ -11,9 +11,9 @@ module FPM
 
       # Load the given file and instantiate an object. Wrap the class in an
       # anonymous module to avoid namespace cluttering. (see Kernel.load)
-      def load_recipe(filename, config, &callback)
+      def load_recipe(filename, config, recipe_config, &callback)
         Kernel.load(filename, true)
-        callback.call(@recipe.new(filename, config))
+        callback.call(@recipe.new(filename, config, recipe_config))
       end
 
       def add_recipe_class(klass)

--- a/lib/fpm/cookery/package/package.rb
+++ b/lib/fpm/cookery/package/package.rb
@@ -1,4 +1,5 @@
 require 'fpm/cookery/exceptions'
+require 'fpm/cookery/log'
 
 module FPM
   module Cookery
@@ -6,9 +7,10 @@ module FPM
       class Package
         attr_reader :recipe, :config, :fpm
 
-        def initialize(recipe, config = {})
+        def initialize(recipe, config = {}, recipe_config = {})
           @recipe = recipe
           @config = config
+          @recipe_config = recipe_config
           @fpm = fpm_object
 
           @fpm.name = recipe.name

--- a/lib/fpm/cookery/packager.rb
+++ b/lib/fpm/cookery/packager.rb
@@ -17,9 +17,10 @@ module FPM
 
       attr_reader :recipe, :config
 
-      def initialize(recipe, config = {})
+      def initialize(recipe, config = {}, recipe_config={})
         @recipe = recipe
         @config = config
+        @recipe_config = config
       end
 
       def skip_package?

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -107,11 +107,19 @@ module FPM
 
         def apply_recipe_data(recipe_config=recipe_data)
           recipe_config.each_pair do |k, v|
-            if self.respond_to?(k)
-              current = self.send(k)
+            meth_sym = k.to_sym
+
+            if self.respond_to?(meth_sym, true)
+              current = self.send(meth_sym)
 
               if !defined? current or current.nil?
-                self.send(k, v)
+                self.send(meth_sym, v)
+              end
+
+              if current.is_a?(Hash) or current.is_a?(Array)
+                if current.empty?
+                  self.send(meth_sym, v)
+                end
               end
             end
           end
@@ -180,6 +188,7 @@ module FPM
       def initialize(filename, config, recipe_config)
         super(filename, config, recipe_config)
         self.apply_recipe_data(recipe_config)
+FPM::Cookery::Log.warn(self.inspect)
 
         @source_handler = SourceHandler.new(Source.new(source, spec), cachedir, builddir)
       end

--- a/lib/fpm/cookery/recipe_config.rb
+++ b/lib/fpm/cookery/recipe_config.rb
@@ -1,0 +1,43 @@
+require 'erb'
+require 'yaml'
+
+module FPM
+  module Cookery
+    class ErbInject
+      def initialize(hash)
+        @hash = hash.dup
+      end
+
+      def method_missing(meth, *args, &block)
+        @hash[meth.to_sym]
+      end
+
+      def get_binding
+        binding
+      end
+    end
+
+    class RecipeConfig
+      def RecipeConfig.load(data)
+        hash = YAML.load(data)
+        injected = ErbInject.new(hash)
+        template = ERB.new(data)
+        parsed = template.result(injected.get_binding)
+
+        # Simple recursion - if an 'injected' value contains embedded ruby,
+        # pass it through this method again until no embedded ruby is left.
+        if /<%.*%>/.match(parsed)
+          RecipeConfig.load(parsed)
+        else
+          YAML.load(parsed)
+        end
+      end
+
+      def RecipeConfig.load_file(paths)
+        path = Array(paths).find {|p| File.exist?(p) }
+        data = File.read(path)
+        RecipeConfig.load(data)
+      end
+    end
+  end
+end

--- a/lib/fpm/cookery/recipe_config.rb
+++ b/lib/fpm/cookery/recipe_config.rb
@@ -3,6 +3,11 @@ require 'yaml'
 
 module FPM
   module Cookery
+    # This class is meant to deal with missing variables or methods called
+    # within an embedded ruby template.  By storing template variables in an
+    # instance variable hash, and by setting the 'method_missing' handler to a
+    # lookup of this hash, any non-existing variable or method will be set to
+    # 'nil' within the template.
     class ErbInject
       def initialize(hash)
         @hash = hash.dup
@@ -17,6 +22,11 @@ module FPM
       end
     end
 
+    # This class interprets YAML documents, optionally containing
+    # embedded ruby, and returns their contents as a hash.  By using the
+    # ErbInject class, above, it avoids erroring out on missing variables or
+    # methods, enabling keys of the interpreted hash to be interpolated into
+    # the template.
     class RecipeConfig
       def RecipeConfig.load(data)
         hash = YAML.load(data)
@@ -26,15 +36,14 @@ module FPM
 
         # Simple recursion - if an 'injected' value contains embedded ruby,
         # pass it through this method again until no embedded ruby is left.
-        if /<%.*%>/.match(parsed)
+        if /<%.*?%>/m.match(parsed)
           RecipeConfig.load(parsed)
         else
           YAML.load(parsed)
         end
       end
 
-      def RecipeConfig.load_file(paths)
-        path = Array(paths).find {|p| File.exist?(p) }
+      def RecipeConfig.load_file(path)
         data = File.read(path)
         RecipeConfig.load(data)
       end

--- a/recipes/redis/config.yml
+++ b/recipes/redis/config.yml
@@ -1,0 +1,20 @@
+:directories:
+    - that
+    - the other
+
+:patches:
+    - 'patches/test.patch'
+    - 'patches/other.patch'
+
+:md5: 'c4b0b5e4953a11a503cb54cf6b09670e'
+
+:name: 'redis-server'
+:version: '2.4.2'
+
+:version: '2.4.2'
+:archive: "redis-<%= version %>.tar.gz"
+:source: 'http://redis.googlecode.com/files/<%= archive %>'
+
+:description: 'An advanced key-value store.'
+:conflicts: 'redis-server'
+:config_files: '/etc/redis/redis.conf'

--- a/recipes/redis/recipe.rb
+++ b/recipes/redis/recipe.rb
@@ -1,3 +1,4 @@
+require 'fpm/cookery/log'
 class Redis < FPM::Cookery::Recipe
   homepage 'http://redis.io'
 
@@ -10,18 +11,18 @@ class Redis < FPM::Cookery::Recipe
   #source   'https://github.com/antirez/redis', :with => :git, :branch => '2.4'
   #source   'https://github.com/antirez/redis', :with => :git, :sha => '072a905'
 
-  source    'http://redis.googlecode.com/files/redis-2.4.2.tar.gz'
-  md5      'c4b0b5e4953a11a503cb54cf6b09670e'
+  #source    'http://redis.googlecode.com/files/redis-2.4.2.tar.gz'
+  #md5      'c4b0b5e4953a11a503cb54cf6b09670e'
 
-  name     'redis-server'
-  version  '2.4.2'
-#  revision '0' # => redis-server-2.2.5+fpm1
+  #name     'redis-server'
+  #version  '2.4.2'
+  #revision '0' # => redis-server-2.2.5+fpm1
 
-  description 'An advanced key-value store.'
+  #description 'An advanced key-value store.'
 
-  conflicts 'redis-server'
+  #conflicts 'redis-server'
 
-  config_files '/etc/redis/redis.conf'
+  #config_files '/etc/redis/redis.conf'
 
   patches 'patches/test.patch'
 


### PR DESCRIPTION
This PR is more of an RFC given my weak Ruby-fu.  The idea is to allow
configuration data like source URL, package name, etc., to be specified in a
YAML file (optionally containing embedded Ruby) rather than in the recipe class
itself.  I find this approach clearer, as it separates data from business
logic.

The basic idea is to have a YAML file (by default, `config.yml` in the same
directory as `recipe.rb`) of the form: 
```
:branch: 'my-branch'
:source: 
    - 'http://svn.mysite.com/<%= branch %>'
    - :with: :svn
:depends:
    - perl
    - pcre-devel
# And so on...
```
Then, `fpm-cookery` automatically calls any methods whose names correspond to
the top-level keys of the hash created by loading the YAML file.  Bonus: the
YAML data is processed recursively, so you can use data from the file as
template variables for ERB (see the use of `branch`, above).

Please let me know what you think of this idea.  If it looks useful, I can set
up some test cases to make sure everything works as expected.  Thanks!
