### PR TITLE
Stop translating underscores in configure args

### DIFF
--- a/lib/fpm/cookery/utils.rb
+++ b/lib/fpm/cookery/utils.rb
@@ -24,7 +24,6 @@ module FPM
         if args.last.is_a?(Hash)
           opts = args.pop
           args += opts.map{ |k,v|
-            option = k.to_s.gsub('_','-')
             if v == true
               "--#{option}"
             else


### PR DESCRIPTION
This breaks nginx configuration.  See the configure arguments here:
https://github.com/nginx/nginx/blob/master/auto/options

Is there a good reason for this translation?  Somehow the user didn't actually intend an underscore?