### PR TITLE
Support tar.xz files

### DIFF
--- a/lib/fpm/cookery/source_handler/curl.rb
+++ b/lib/fpm/cookery/source_handler/curl.rb
@@ -23,7 +23,7 @@ module FPM
         def extract(config = {})
           Dir.chdir(builddir) do
             case local_path.extname
-            when '.bz2', '.gz', '.tgz'
+            when '.bz2', '.gz', '.tgz', '.xz'
               safesystem('tar', 'xf', local_path)
             when '.shar', '.bin'
               File.chmod(0755, local_path)


### PR DESCRIPTION
There are lots of sources which are of the extension tar.xz now, it is becoming a popular compression type. This PR allows fpm-cookery to support tar.xz's in its unpacking algorithm.