### PR TITLE
rpmbuild uses single angle brackets for relative dependencies

### DIFF
--- a/lib/fpm/cookery/dependency_inspector.rb
+++ b/lib/fpm/cookery/dependency_inspector.rb
@@ -87,8 +87,8 @@ module FPM
           return false
         end
 
-        # We can't handle >=, <<, >>, <=
-        if package =~ />=|<<|>>|<=/
+        # We can't handle >=, <<, >>, <=, <, >
+        if package =~ />=|<<|>>|<=|<|>/
           Log.warn "Required package '#{package}' has a relative version requirement; not attempting to find/install a package to satisfy"
           return false
         end


### PR DESCRIPTION
When building an RPM file with relative dependencies, a single angle bracket (< or >) is used.

Upstream breaks when using a single angle bracket in master. If you try to use << or >> instead, rpmbuild throws an error and dies.