### PR TITLE
run bootstrap method during install_deps

### DIFF
--- a/lib/fpm/cookery/packager.rb
+++ b/lib/fpm/cookery/packager.rb
@@ -44,6 +44,9 @@ module FPM
       end
 
       def install_deps
+        if recipe.respond_to?('bootstrap')
+          recipe.bootstrap
+        end
         DependencyInspector.verify!(recipe.depends, recipe.build_depends)
         Log.info("All dependencies installed!")
       end


### PR DESCRIPTION
this allows us to run arbitrary commands to bootstrap a build node
before installing deps, for example configuring apt repositories