### PR TITLE
Update dependency_inspector.rb

### DIFF
--- a/lib/fpm/cookery/dependency_inspector.rb
+++ b/lib/fpm/cookery/dependency_inspector.rb
@@ -70,7 +70,7 @@ module FPM
           :ensure => "present"
         })
         result = Puppet::Resource.indirection.save(resource)[1]
-        failed = Puppet::Resource.indirection.save(resource)[1].resource_statuses.values.first.failed
+        failed = result.resource_statuses.values.first.failed
         if failed
           Log.fatal "While processing depends package '#{package}':"
           result.logs.each {|log_line| Log.fatal log_line}


### PR DESCRIPTION
reuse previous call.

i don't see why not, it was added in d2bb9bd via #17 which doesn't explain much why need to invoke again.

otoh, i don't know Puppet internals