### PR TITLE
Added support for omnibus dependencies that are not installed during …

### DIFF
--- a/lib/fpm/cookery/omnibus_packager.rb
+++ b/lib/fpm/cookery/omnibus_packager.rb
@@ -50,6 +50,7 @@ module FPM
           pkg.dispense
 
           @depends += dep_recipe.depends
+          @depends += dep_recipe.package_depends
           Log.info "Finished building #{dep_recipe.name}, moving on to next recipe"
         end
 


### PR DESCRIPTION
Added support to enable dependencies to be passed to omnibus packager without being installed during cook or install-deps commands. This is necessary if 32-bit packages are needed for an RPM because they must be specified like "#{package}(x86-32)", but specifying them that way causes the underlying puppet system to fail.