### PR TITLE
Package depends

### DIFF
--- a/lib/fpm/cookery/omnibus_packager.rb
+++ b/lib/fpm/cookery/omnibus_packager.rb
@@ -13,6 +13,7 @@ module FPM
         @config = config
         @recipe = packager.recipe
         @depends = []
+        @package_depends = []
       end
 
       def load_omnibus_recipes(_recipe)
@@ -56,6 +57,7 @@ module FPM
 
         # Now all child recipes are built; set depends to combined set of dependencies
         recipe.class.depends(@depends.flatten.uniq)
+        recipe.class.package_depends(@package_depends.flatten.uniq)
         Log.info "Combined dependencies: #{recipe.depends.join(', ')}"
 
         recipe.destdir = recipe.omnibus_dir if recipe.omnibus_dir

--- a/lib/fpm/cookery/omnibus_packager.rb
+++ b/lib/fpm/cookery/omnibus_packager.rb
@@ -50,6 +50,7 @@ module FPM
           pkg.dispense
 
           @depends += dep_recipe.depends
+          @depends += dep_recipe.package_depends
           Log.info "Finished building #{dep_recipe.name}, moving on to next recipe"
         end
 

--- a/lib/fpm/cookery/omnibus_packager.rb
+++ b/lib/fpm/cookery/omnibus_packager.rb
@@ -50,7 +50,7 @@ module FPM
           pkg.dispense
 
           @depends += dep_recipe.depends
-          @depends += dep_recipe.package_depends
+          @package_depends += dep_recipe.package_depends
           Log.info "Finished building #{dep_recipe.name}, moving on to next recipe"
         end
 

--- a/lib/fpm/cookery/package/package.rb
+++ b/lib/fpm/cookery/package/package.rb
@@ -18,6 +18,7 @@ module FPM
           @fpm.architecture = recipe.arch.to_s if recipe.arch
 
           @fpm.dependencies += recipe.depends
+          @fpm.dependencies += recipe.package_depends
           @fpm.conflicts += recipe.conflicts
           @fpm.provides += recipe.provides
           @fpm.replaces += recipe.replaces

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -74,7 +74,7 @@ module FPM
               :license, :omnibus_package, :omnibus_dir, :chain_package,
               :default_prefix
 
-      attr_rw_list :build_depends, :config_files, :conflicts, :depends,
+      attr_rw_list :build_depends, :config_files, :conflicts, :depends, :package_depends,
                    :exclude, :patches, :provides, :replaces, :omnibus_recipes,
                    :omnibus_additional_paths, :chain_recipes, :directories
 

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -45,6 +45,7 @@ describe 'Package' do
       section 'langs'
       arch 'all'
       depends 'ab', 'c'
+      package_depends 'de', 'f'
       conflicts 'xz', 'y'
       provides 'foo-package'
       replaces 'foo-old'
@@ -83,7 +84,11 @@ describe 'Package' do
     end
 
     it 'sets the dependencies' do
-      expect(package.fpm.dependencies).to eq(['ab', 'c'])
+      expect(package.fpm.dependencies).to include('ab', 'c')
+    end
+
+    it 'includes the package only dependencies' do
+      expect(package.fpm.dependencies).to include('de', 'f')
     end
 
     it 'sets the conflicts' do


### PR DESCRIPTION
This PR adds support for explicitly setting package names to be passed to FPM without first trying to install them as either build or runtime dependencies.  This is required when you need to specify the architecture of a dependency and your build target is an RPM.  Without this PR if you specify the dependency with 'i686' puppet is happy but RPM can't resolve the dependency on install.  If you specify the dependency as '(x86-32)' then RPM is happy but puppet fails.

If the PR is accepted, I will update the wiki accordingly. 