### PR TITLE
Rework dependency handling on "fpm-cook package"

### DIFF
--- a/lib/fpm/cookery/cli.rb
+++ b/lib/fpm/cookery/cli.rb
@@ -19,8 +19,10 @@ module FPM
       option ['-p', '--platform'], 'PLATFORM', 'set the target platform (centos, ubuntu, debian)'
       option ['-q', '--quiet'], :flag, 'Disable verbose output like progress bars'
       option ['-V', '--version'], :flag, 'show fpm-cookery and fpm version'
-      option '--[no-]deps', :flag, 'enable/disable dependency checking',
-        :attribute_name => 'dependency_check'
+      option '--[no-]install-build-depends', :flag, 'enable/disable installation of build dependencies',
+        :attribute_name => 'install_build_depends'
+      option '--[no-]install-depends', :flag, 'enable/disable installation of dependencies',
+        :attribute_name => 'install_depends'
       option '--tmp-root', 'DIR', 'directory root for temporary files',
         :attribute_name => 'tmp_root'
       option '--pkg-dir', 'DIR', 'directory for built packages',
@@ -128,6 +130,7 @@ module FPM
 
         def exec(config, recipe, packager)
           packager.install_deps
+          Log.info('All dependencies installed!')
         end
       end
 
@@ -142,6 +145,7 @@ module FPM
           else
             packager.install_build_deps
           end
+          Log.info('Build dependencies installed!')
         end
       end
 

--- a/lib/fpm/cookery/config.rb
+++ b/lib/fpm/cookery/config.rb
@@ -6,14 +6,15 @@ module FPM
     class Config
       ATTRIBUTES = [
         :color, :debug, :target, :platform, :maintainer, :vendor,
-        :skip_package, :keep_destdir, :dependency_check, :quiet,
-        :tmp_root, :pkg_dir, :cache_dir
+        :skip_package, :keep_destdir, :install_build_depends,
+        :install_depends, :quiet, :tmp_root, :pkg_dir, :cache_dir
       ].freeze
 
       DEFAULTS = {
         :color => true,
         :debug => false,
-        :dependency_check => true,
+        :install_build_depends => false,
+        :install_depends => false,
         :skip_package => false,
         :keep_destdir => false,
         :quiet => false

--- a/lib/fpm/cookery/omnibus_packager.rb
+++ b/lib/fpm/cookery/omnibus_packager.rb
@@ -52,8 +52,11 @@ module FPM
 
         dep_recipes = load_omnibus_recipes(recipe)
         dep_recipes.uniq.each do |dep_recipe|
-          pkg = FPM::Cookery::Packager.new(dep_recipe, :skip_package => true,
-                                          :keep_destdir => true, :dependency_check => config.dependency_check )
+          packager_config = config.to_hash.merge({
+            :skip_package => true,
+            :keep_destdir => true
+          })
+          pkg = FPM::Cookery::Packager.new(dep_recipe, packager_config)
           pkg.target = FPM::Cookery::Facts.target.to_s
 
           Log.info "Located recipe for child recipe #{dep_recipe.name}; starting build"

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -99,12 +99,20 @@ describe 'Config' do
     common_tests(:keep_destdir)
   end
 
-  describe '#dependency_check' do
+  describe '#install_build_depends' do
     it 'defaults to false' do
-      expect(default_config.dependency_check).to eq(true)
+      expect(default_config.install_build_depends).to eq(false)
     end
 
-    common_tests(:dependency_check)
+    common_tests(:install_build_depends)
+  end
+
+  describe '#install_depends' do
+    it 'defaults to false' do
+      expect(default_config.install_depends).to eq(false)
+    end
+
+    common_tests(:install_depends)
   end
 
   describe '#tmp_root' do
@@ -145,7 +153,8 @@ describe 'Config' do
         :vendor => nil,
         :skip_package => false,
         :keep_destdir => false,
-        :dependency_check => true,
+        :install_build_depends => false,
+        :install_depends => false,
         :quiet => false
       })
     end


### PR DESCRIPTION
- Remove --no-deps option.
- Add --install-build-depends option to install build dependencies only.
- Add --install-depends option to install all declared dependencies.
- Disable automatic dependency installation on "fpm-cook package". Use
  the new --install-depends/--install-build-depends options to install
  dependencies and build the project with one command.

Based on discussions in #116. Please review and send feedback, thanks! :smiley: 