### PR TITLE
support for virtualenv

### DIFF
--- a/lib/fpm/cookery/package/virtualenv.rb
+++ b/lib/fpm/cookery/package/virtualenv.rb
@@ -1,0 +1,25 @@
+require 'fpm/package/virtualenv'
+require 'fpm/cookery/package/package'
+
+module FPM
+  module Cookery
+    module Package
+      class Virtualenv < FPM::Cookery::Package::Package
+        def fpm_object
+          FPM::Package::Virtualenv.new
+        end
+
+        def package_setup
+          fpm.version = recipe.version
+          fpm.attributes[:virtualenv_pypi] = recipe.virtualenv_pypi unless recipe.virtualenv_pypi.nil?
+          fpm.attributes[:virtualenv_install_location] = recipe.virtualenv_install_location unless recipe.virtualenv_install_location.nil?
+          fpm.attributes[:virtualenv_fix_name?] = false
+        end
+
+        def package_input
+          fpm.input(recipe.name)
+        end
+      end
+    end
+  end
+end

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -13,6 +13,7 @@ require 'fpm/cookery/package/gem'
 require 'fpm/cookery/package/npm'
 require 'fpm/cookery/package/pear'
 require 'fpm/cookery/package/python'
+require 'fpm/cookery/package/virtualenv'
 
 module FPM
   module Cookery
@@ -218,6 +219,13 @@ module FPM
 
       def input(config)
         FPM::Cookery::Package::PEAR.new(self, config)
+      end
+    end
+
+    class VirtualenvRecipe < BaseRecipe
+      attr_rw :virtualenv_pypi, :virtualenv_install_location, :virtualenv_fix_name
+      def input(config)
+        FPM::Cookery::Package::Virtualenv.new(self, config)
       end
     end
   end


### PR DESCRIPTION
Because the support for Python virtualenvs has been added to `fpm` in https://github.com/jordansissel/fpm/commit/ae443f9b7ca0794d1285f96462432f7f1ec6a6f9, it would be nice to have fpm-cookery support it also.
This PR implements this.