### PR TITLE
let `extract_source` to `builddir` when more than one dirs being extracted

### DIFF
--- a/lib/fpm/cookery/source_handler/curl.rb
+++ b/lib/fpm/cookery/source_handler/curl.rb
@@ -68,16 +68,8 @@ module FPM
           when 1
             entries.first
           else
-            # Use the directory that was created last.
-            dir = entries.sort do |a, b|
-              File.stat(a).ctime <=> File.stat(b).ctime
-            end.last
-
-            if File.exist?(dir)
-              dir
-            else
-              raise "Could not find source directory for #{local_path.basename}"
-            end
+            # Use current dir when more then one dirs being extracted
+            Dir.pwd
           end
         end
       end


### PR DESCRIPTION
Hi,

Sometimes, a tar ball does not retain the parent directory. e.g. After type `tar -xvf abc.tar.gz` , there are some sub directories under the `builddir` like src/ doc/... instead of the abc folder.

The original code chooses the latest extracted folder. I guess it make more sense if we return `builddir` directly.

The new code return `Dir.pwd`, since already changed to `builddir`.

Made no change to the tests  since the change itself didn't break the test. 

Regards
Yichao