### PR TITLE
Specify `rpm_os` in recipe.rb

### DIFF
--- a/lib/fpm/cookery/package/package.rb
+++ b/lib/fpm/cookery/package/package.rb
@@ -34,6 +34,7 @@ module FPM
           @fpm.attributes[:rpm_defattrfile] = '-'
           @fpm.attributes[:rpm_defattrdir] = '-'
           @fpm.attributes[:excludes] = recipe.exclude
+          @fpm.attributes[:rpm_os] = recipe.rpm_os     # specify the os type of package on RPM
 
           # Package type specific code should be called in package_setup.
           package_setup

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -75,7 +75,7 @@ module FPM
               :revision, :section, :sha1, :sha256, :spec, :vendor, :version,
               :pre_install, :post_install, :pre_uninstall, :post_uninstall,
               :license, :omnibus_package, :omnibus_dir, :chain_package,
-              :default_prefix
+              :default_prefix, :rpm_os
 
       attr_rw_list :build_depends, :config_files, :conflicts, :depends,
                    :exclude, :patches, :provides, :replaces, :omnibus_recipes,


### PR DESCRIPTION
Hi, @bernd 

I was trying to build a rpm that packages my Java application on OSX. But the package was tagged as `os=>darwin`, which led to an error when I installed on a CentOS.

Hopefully, fpm provides an option named `rpm_os`: https://github.com/jordansissel/fpm/issues/309

This merge request might walk around this problem in fpm-cookery.

Best regards
Yichao