### PR TITLE
Don't dereference symlinks in #install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmp-dest/
 .vagrant
 Vagrantfile
 /vendor
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@ tmp-dest/
 .vagrant
 Vagrantfile
 /vendor
+
+# vim backups
 *~

--- a/lib/fpm/cookery/path.rb
+++ b/lib/fpm/cookery/path.rb
@@ -66,7 +66,7 @@ module FPM
 
         # We used to use :preserve => true here, but that broke package
         # building when the file tree contains broken symlinks.
-        FileUtils.cp_r src, dst
+        FileUtils.cp_r src, dst, :dereference_root => false
 
         # if File.symlink? src
         #   # we use the BSD mv command because FileUtils copies the target and

--- a/lib/fpm/cookery/path.rb
+++ b/lib/fpm/cookery/path.rb
@@ -66,6 +66,9 @@ module FPM
 
         # We used to use :preserve => true here, but that broke package
         # building when the file tree contains broken symlinks.
+        # :dereference_root => false, results in symlinks being copied instead
+        # of dereferencing them first. Copying a symlink that points to a
+        # non-existent file is not an error.
         FileUtils.cp_r src, dst, :dereference_root => false
 
         # if File.symlink? src


### PR DESCRIPTION
Prevents `FileUtils.cp_r` from dereferencing symlinks during `#install`.

I haven't seen any issues with this in my limited testing so far. My aim was to be able to easily install a directory of libraries and their symlinks when creating "broken out" packages (ie. `thing`, `thing-libs`, etc).

For example: with this patch `lib('thing').install Dir.glob('/some/path/usr/lib/*.so*')` will successfully copy the libraries and symlinks to `lib('thing')` without dereferencing the symlinks thus avoiding the need for workarounds in this situation.

I also ignored `vim` backups in the `.gitignore`.