### PR TITLE
Added support for DirRecipe and Directory Handler

### DIFF
--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -14,6 +14,7 @@ require 'fpm/cookery/package/npm'
 require 'fpm/cookery/package/pear'
 require 'fpm/cookery/package/python'
 require 'fpm/cookery/package/virtualenv'
+require 'fpm/cookery/log'
 
 module FPM
   module Cookery
@@ -230,6 +231,30 @@ module FPM
       attr_rw :virtualenv_pypi, :virtualenv_install_location, :virtualenv_fix_name
       def input(config)
         FPM::Cookery::Package::Virtualenv.new(self, config)
+      end
+    end
+
+    # Helps packaging a directory of content
+    class DirRecipe < Recipe
+
+      def input(config)
+        FPM::Cookery::Package::Dir.new(self, config)
+      end
+
+      # Dir Recipes by default build action.
+      def build
+      end
+
+      # Default action for a dir recipe install is to copy items selected
+      def install
+        FileUtils.cp_r File.join(builddir, '.'), destdir
+        # Remove build cookies
+        %w(build extract).each do |cookie|
+          Dir.glob("#{destdir}/.#{cookie}-cookie-*").each do |f|
+            Log.info "Deleting FPM Cookie #{f}"
+            File.delete(f)
+          end
+        end
       end
     end
   end

--- a/lib/fpm/cookery/source_handler.rb
+++ b/lib/fpm/cookery/source_handler.rb
@@ -5,6 +5,7 @@ require 'fpm/cookery/source_handler/git'
 require 'fpm/cookery/source_handler/hg'
 require 'fpm/cookery/source_handler/local_path'
 require 'fpm/cookery/source_handler/noop'
+require 'fpm/cookery/source_handler/directory'
 require 'fpm/cookery/log'
 
 module FPM

--- a/lib/fpm/cookery/source_handler/directory.rb
+++ b/lib/fpm/cookery/source_handler/directory.rb
@@ -1,0 +1,33 @@
+require 'fpm/cookery/source_handler/template'
+require 'fpm/cookery/log'
+require 'fileutils'
+
+module FPM
+  module Cookery
+    class SourceHandler
+      class Directory < FPM::Cookery::SourceHandler::Template
+        CHECKSUM = false
+        NAME = :directory
+
+        def fetch(config = {})
+            path = source.path
+            cached_file = File.join(@cachedir, path)
+            if File.exist? cached_file
+              Log.info "Using cached file #{cached_file}"
+            else
+              # Exclude source directory
+              path = File.join(path,'.')
+              Log.info "Copying #{path} to cache"
+              FileUtils.cp_r(path, cachedir)
+            end
+          cachedir
+        end
+
+        def extract(config = {})
+          FileUtils.cp_r(File.join(cachedir,'.'), builddir)
+          builddir
+        end
+      end
+    end
+  end
+end

--- a/lib/fpm/cookery/version.rb
+++ b/lib/fpm/cookery/version.rb
@@ -1,5 +1,5 @@
 module FPM
   module Cookery
-    VERSION = '0.31.0'
+    VERSION = '0.32.0'
   end
 end


### PR DESCRIPTION
This PR provides support for easily taking a directory tree and turning it into a package.  

The PR includes a new recipe type called DirRecipe which implements an empty build and an install phase that copies files over from the build dir.  It also deletes cookies, otherwise they end up in the FPM artifact.

The PR also includes a new handler of type 'directory' that specifies the part of the directory tree to use as source. 

I use this setup often for packaging and versioning things like scripts or other elements that need to be versioned and packaged.
Here is an example use.

```
class Scripts < FPM::Cookery::DirRecipe
  homepage 'https://www.example.com/'
  source File.join('/home/vagrant/build/stage/'), :with => :directory

  name 'scripts'
  version '1:1.0.0'
  revision '0'
  arch 'all'
  vendor 'me'
  maintainer 'Foo Bar <foo@bar.com>'
  description 'Some scripts'

  def build
    FileUtils.chmod("u=rw,go=r", Dir.glob(File.join(builddir,'/path/to/place/scripts/*')))
  end
end
```


If accepted, I will update the docs/wiki. 
