### PR TITLE
Add lsbcodename

### DIFF
--- a/lib/fpm/cookery/facts.rb
+++ b/lib/fpm/cookery/facts.rb
@@ -19,6 +19,12 @@ module FPM
         @osrelease ||= Facter.fact(:operatingsystemrelease).value
       end
 
+      def self.lsbcodename
+        codename = Facter.fact(:lsbcodename)
+
+        @lsbcodenode ||= codename.nil? ? nil : codename.value.downcase.to_sym
+      end
+
       def self.osmajorrelease
         @osmajorrelease ||= Facter.fact(:operatingsystemmajrelease).value
       end

--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -23,6 +23,30 @@ describe "Facts" do
     end
   end
 
+  describe "lsbcodename" do
+    context "where lsbcodename is present" do
+      before do
+        Facter.class_eval do
+          def self.fact(v)
+            v == :lsbcodename ? OpenStruct.new(:value => 'trusty') : nil
+          end
+        end
+      end
+
+      it "returns the current platforms codename" do
+        expect(FPM::Cookery::Facts.lsbcodename).to eq :trusty
+      end
+    end
+
+    context "where lsbcodename is not present" do
+      it "returns nil" do
+        allow(Facter).to receive(:fact).with(:lsbcodename).and_return(nil)
+
+        expect(FPM::Cookery::Facts.lsbcodename).to be_nil
+      end
+    end
+  end
+
   describe "platform" do
     include_context "mock facts", { :operatingsystem => 'CentOS' }
 


### PR DESCRIPTION
We would like to access  `lsbcodename` from our recipes.

This will allow us to name packages based on the ubuntu release name rather than just the version number.