### PR TITLE
Add `inspect` subcommand

### DIFF
--- a/fpm-cookery.gemspec
+++ b/fpm-cookery.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "puppet", "~> 3.4"
   s.add_runtime_dependency "addressable", "~> 2.3.8"
   s.add_runtime_dependency "systemu"
-  s.add_runtime_dependency "json", ">= 1.7.7.", "< 2.0"
 end

--- a/fpm-cookery.gemspec
+++ b/fpm-cookery.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "puppet", "~> 3.4"
   s.add_runtime_dependency "addressable", "~> 2.3.8"
   s.add_runtime_dependency "systemu"
+  s.add_runtime_dependency "json", ">= 1.7.7.", "< 2.0"
 end


### PR DESCRIPTION
Per the feature request from @josegonzalez in #160.

Adds an `inspect` subcommand that:
1. Prints a formatted ERB template string if `--format` was provided, or
2. Prints the recipe's attributes as a JSON object without `--format`.

---

N.B. This branch is experiencing build failures due to the `json` gem dependency issue.  I will open a separate PR that updates the `gemspec` to peg the dependency at a version compatible with pre-2.0 Rubies.