### PR TITLE
Pegged json dependency to version compatible with pre-2.0 Rubies

### DIFF
--- a/fpm-cookery.gemspec
+++ b/fpm-cookery.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "puppet", "~> 3.4"
   s.add_runtime_dependency "addressable", "~> 2.3.8"
   s.add_runtime_dependency "systemu"
+  s.add_runtime_dependency "json", ">= 1.7.7", "< 2.0"
 end


### PR DESCRIPTION
Addresses the `json` dependency issue noted in #157 and #165.