### PR TITLE
Rejiggered Facter-related code to use `Facter.value`

### DIFF
--- a/fpm-cookery.gemspec
+++ b/fpm-cookery.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "rspec", "~> 3.0"
+  s.add_development_dependency "rspec", "~> 3.3"
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"
   s.add_development_dependency "simplecov", "~> 0.11"

--- a/lib/fpm/cookery/facts.rb
+++ b/lib/fpm/cookery/facts.rb
@@ -3,47 +3,55 @@ require 'facter'
 module FPM
   module Cookery
     class Facts
-      def self.arch
-        @arch ||= Facter.fact(:architecture).value.downcase.to_sym
-      end
+      class << self
+        def arch
+          @arch ||= value(:architecture)
+        end
 
-      def self.platform
-        @platform ||= Facter.fact(:operatingsystem).value.downcase.to_sym
-      end
+        def platform
+          @platform ||= value(:operatingsystem)
+        end
 
-      def self.platform=(value)
-        @platform = value.downcase.to_sym
-      end
+        def platform=(value)
+          @platform = value.downcase.to_sym
+        end
 
-      def self.osrelease
-        @osrelease ||= Facter.fact(:operatingsystemrelease).value
-      end
+        def osrelease
+          @osrelease ||= value(:operatingsystemrelease, false)
+        end
 
-      def self.lsbcodename
-        codename = Facter.fact(:lsbcodename)
+        def lsbcodename
+          @lsbcodename ||= value(:lsbcodename)
+        end
 
-        @lsbcodenode ||= codename.nil? ? nil : codename.value.downcase.to_sym
-      end
+        def osmajorrelease
+          @osmajorrelease ||= value(:operatingsystemmajrelease, false)
+        end
 
-      def self.osmajorrelease
-        @osmajorrelease ||= Facter.fact(:operatingsystemmajrelease).value
-      end
+        def target
+          @target ||= case platform
+                      when :centos, :redhat, :fedora, :amazon,
+                           :scientific, :oraclelinux           then :rpm
+                      when :debian, :ubuntu                    then :deb
+                      when :darwin                             then :osxpkg
+                      end
+        end
 
-      def self.target
-        @target ||= case platform
-                    when :centos, :redhat, :fedora, :amazon,
-                         :scientific, :oraclelinux           then :rpm
-                    when :debian, :ubuntu                    then :deb
-                    when :darwin                             then :osxpkg
-                    end
-      end
+        def target=(value)
+          @target = value.to_sym
+        end
 
-      def self.target=(value)
-        @target = value.to_sym
-      end
+        def reset!
+          instance_variables.each {|v| instance_variable_set(v, nil) }
+        end
 
-      def self.reset!
-        instance_variables.each {|v| instance_variable_set(v, nil) }
+        private
+
+        def value(fact_name, symbolize = true)
+          v = Facter.value(fact_name)
+          return v if v.nil? or !symbolize
+          return v.downcase.to_sym
+        end
       end
     end
   end

--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
-require 'ostruct'
 require 'fpm/cookery/facts'
 
 shared_context "mock facts" do |facts = {}|
   before do
     facts.each_pair do |k, v|
-      allow(Facter).to receive(:fact).with(k).and_return(OpenStruct.new(:value => v))
+      allow(Facter).to receive(:value).with(k).and_return(v)
     end
   end
 end
@@ -25,13 +24,7 @@ describe "Facts" do
 
   describe "lsbcodename" do
     context "where lsbcodename is present" do
-      before do
-        Facter.class_eval do
-          def self.fact(v)
-            v == :lsbcodename ? OpenStruct.new(:value => 'trusty') : nil
-          end
-        end
-      end
+      include_context "mock facts", { :lsbcodename => 'trusty' }
 
       it "returns the current platforms codename" do
         expect(FPM::Cookery::Facts.lsbcodename).to eq :trusty
@@ -39,9 +32,9 @@ describe "Facts" do
     end
 
     context "where lsbcodename is not present" do
-      it "returns nil" do
-        allow(Facter).to receive(:fact).with(:lsbcodename).and_return(nil)
+      include_context "mock facts", { :lsbcodename => nil }
 
+      it "returns nil" do
         expect(FPM::Cookery::Facts.lsbcodename).to be_nil
       end
     end


### PR DESCRIPTION
I saw testing failures in #165 that traced to `Facter.fact(:somefact).value` returning `nil`.  This PR addresses the issue by using the `Facter.value` method instead of `Facter.fact`, adding the `FPM::Cookery::Facts.value` wrapper method to short-circuit prior to calling `.downcase.to_sym` when the requested value is `nil`.  I also updated the related spec file to call `Facter.value`, and simplified testing of the `:lsbcodename` fact.

The PR also bumps the `rspec` dependency to 3.3 in order to gain access to the `--bisect` option that helps track down ordering-dependent test failures.