### PR TITLE
Add multiple source support

### DIFF
--- a/lib/fpm/cookery/source.rb
+++ b/lib/fpm/cookery/source.rb
@@ -7,8 +7,15 @@ module FPM
 
       def initialize(url, options = nil)
         options ||= {}
-        @url = Addressable::URI.parse(url.to_s)
-        @provider = options[:with]
+
+        if url.is_a? Array
+          @url = url
+          @provider = :multi_source
+        else
+          @url = Addressable::URI.parse(url.to_s)
+          @provider = options[:with]
+        end
+
         @options = options
       end
 
@@ -26,7 +33,7 @@ module FPM
       end
 
       def url
-        @url.to_s
+        @provider == :multi_source ? @url : @url.to_s
       end
       [:to_s, :to_str].each { |m| alias_method m, :url }
 

--- a/lib/fpm/cookery/source_handler.rb
+++ b/lib/fpm/cookery/source_handler.rb
@@ -6,6 +6,7 @@ require 'fpm/cookery/source_handler/hg'
 require 'fpm/cookery/source_handler/local_path'
 require 'fpm/cookery/source_handler/noop'
 require 'fpm/cookery/source_handler/directory'
+require 'fpm/cookery/source_handler/multi_source'
 require 'fpm/cookery/log'
 require 'fpm/cookery/exceptions'
 

--- a/lib/fpm/cookery/source_handler.rb
+++ b/lib/fpm/cookery/source_handler.rb
@@ -12,6 +12,29 @@ require 'fpm/cookery/exceptions'
 module FPM
   module Cookery
     class SourceHandler
+      class << self
+        def handler_to_class(provider)
+          begin
+            maybe_klass = self.const_get(provider.to_s.split('_').map(&:capitalize).join)
+
+            instance_method_map = Hash[maybe_klass.instance_methods.map { |m| [m, true] }]
+            missing_methods = REQUIRED_METHODS.find_all { |m| !instance_method_map.key?(m) }
+
+            unless missing_methods.empty?
+              formatted_missing = missing_methods.map { |m| "`#{m}'" }.join(', ')
+              message = %{#{maybe_klass} does not implement required method(s): #{formatted_missing}}
+              Log.error message
+              raise Error::Misconfiguration, message
+            end
+
+            maybe_klass
+          rescue NameError => e
+            Log.error "Specified provider #{provider} does not exist."
+            raise Error::Misconfiguration, e.message
+          end
+        end
+      end
+
       DEFAULT_HANDLER = :curl
       LOCAL_HANDLER = :local_path
       REQUIRED_METHODS = [:fetch, :extract]
@@ -40,30 +63,9 @@ module FPM
 
       private
       def get_source_handler(provider)
-        klass = handler_to_class(provider)
+        klass = SourceHandler.handler_to_class(provider)
         # XXX Refactor handler to avoid passing the options.
         klass.new(@source, @source.options, @cachedir, @builddir)
-      end
-
-      def handler_to_class(provider)
-        begin
-          maybe_klass = self.class.const_get(provider.to_s.split('_').map(&:capitalize).join)
-
-          instance_method_map = Hash[maybe_klass.instance_methods.map { |m| [m, true] }]
-          missing_methods = REQUIRED_METHODS.find_all { |m| !instance_method_map.key?(m) }
-
-          unless missing_methods.empty?
-            formatted_missing = missing_methods.map { |m| "`#{m}'" }.join(', ')
-            message = %{#{maybe_klass} does not implement required method(s): #{formatted_missing}}
-            Log.error message
-            raise Error::Misconfiguration, message
-          end
-
-          maybe_klass
-        rescue NameError => e
-          Log.error "Specified provider #{provider} does not exist."
-          raise Error::Misconfiguration, e.message
-        end
       end
     end
   end

--- a/lib/fpm/cookery/source_handler/curl.rb
+++ b/lib/fpm/cookery/source_handler/curl.rb
@@ -21,7 +21,7 @@ module FPM
         end
 
         def extract(config = {})
-          Dir.chdir(builddir) do
+          Dir.chdir((builddir/options[:directory])) do
             case local_path.extname
             when '.bz2', '.gz', '.tgz', '.xz', '.tar'
               safesystem('tar', 'xf', local_path)

--- a/lib/fpm/cookery/source_handler/multi_source.rb
+++ b/lib/fpm/cookery/source_handler/multi_source.rb
@@ -1,0 +1,51 @@
+require 'fpm/cookery/source_handler/template'
+
+module FPM
+  module Cookery
+    class SourceHandler
+      class MultiSource < FPM::Cookery::SourceHandler::Template
+        NAME = :multi_source
+        CHECKSUM = false
+
+        def initialize(source_url, options, cachedir, builddir)
+          super
+
+          @source_handlers = []
+
+          source.url.each do |url|
+            klass = FPM::Cookery::SourceHandler.handler_to_class(url[:with])
+
+            @source_handlers << klass.new(url[:url], url, cachedir, builddir)
+          end
+        end
+
+        def fetch(config = {})
+          Log.info "multi_source handler; fetching..."
+
+          @source_handlers.each do |source_handler|
+            source_handler.fetch(config)
+          end
+
+          Log.info "multi_source handler; fetch complete"
+        end
+
+        def extract(config = {})
+          Log.info "multi_source handler; extracting..."
+
+          extracted = builddir
+
+          @source_handlers.each do |source_handler|
+            if source_handler.options[:main]
+              extracted = source_handler.extract(config)
+            else
+              source_handler.extract(config)
+            end
+          end
+
+          extracted
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
Heya!
One of my recipes requires fetching multiple source files (several tars and git repositories) to build package.
So I've implemented source handler which allows you to specify array of sources in recipe.rb instead of one url.
You can see example of usage [here](https://github.com/sychevyi/fpm-recipes/blob/aa5074e01848f8bc02e32e11521faefaf478875c/openresty/recipe.rb)

Additionally I've added **directory** option to curl source handler, it allows to extract source to builddir sub-directory.

Also it doesn't break any tests (at least `bundle exec rake` runs without failures) and works good for me.