### PR TITLE
Add default package version and guard against nil/empty versions

### DIFF
--- a/lib/fpm/cookery/package/version.rb
+++ b/lib/fpm/cookery/package/version.rb
@@ -16,6 +16,10 @@ module FPM
           :default => '-'
         }
 
+        # fpm sets the default version in FPM::Command; since we bypass the
+        # command line interface, we need to set our own value.
+        DEFAULT_VERSION = '1.0'
+
         attr_reader :version, :epoch, :revision
 
         def initialize(recipe, target, config)
@@ -28,6 +32,10 @@ module FPM
 
         def vendor
           @config[:vendor] || @recipe.vendor
+        end
+
+        def version
+          @version ||= DEFAULT_VERSION
         end
 
         def revision_delimiter
@@ -49,9 +57,7 @@ module FPM
         private
 
         def split_version(version)
-          epoch, version = version.split(':', 2)
-
-          version.nil? ? [epoch, nil] : [version, epoch]
+          (version || '').split(':', 2).reject(&:empty?).reverse
         end
       end
     end

--- a/lib/fpm/cookery/package/version.rb
+++ b/lib/fpm/cookery/package/version.rb
@@ -20,7 +20,7 @@ module FPM
         # command line interface, we need to set our own value.
         DEFAULT_VERSION = '1.0'
 
-        attr_reader :version, :epoch, :revision
+        attr_reader :epoch, :revision
 
         def initialize(recipe, target, config)
           @recipe = recipe

--- a/spec/package_version_spec.rb
+++ b/spec/package_version_spec.rb
@@ -140,4 +140,54 @@ describe 'Version' do
       expect(version.to_str).to eq('1.3-1.foo')
     end
   end
+
+  describe '#version' do
+    context 'given a colon-delimited string in recipe.version' do
+      context 'where version and epoch are defined' do
+        before(:each) { recipe.version = '8675309:3.1.1'}
+
+        it 'returns the version and epoch' do
+          expect(version.version).to eq('3.1.1')
+          expect(version.epoch).to eq('8675309')
+        end
+      end
+
+      context 'where only version is defined' do
+        before(:each) { recipe.version = ':2.1' }
+
+        it 'returns the version and sets epoch to nil' do
+          expect(version.version).to eq('2.1')
+          expect(version.epoch).to be nil
+        end
+      end
+
+      context 'where only epoch is defined' do
+        before(:each) { recipe.version = '12345:' }
+
+        it 'returns the epoch as version and sets epoch to nil' do
+          expect(version.version).to eq('12345')
+          expect(version.epoch).to be nil
+        end
+      end
+
+    end
+
+    context 'given a nil recipe.version' do
+      before(:each) { recipe.version = nil }
+
+      it 'returns the default version' do
+        expect(version.version).to eq(klass::DEFAULT_VERSION)
+        expect(version.epoch).to be nil
+      end
+    end
+
+    context 'given a recipe.version containing the empty string' do
+      before(:each) { recipe.version = '' }
+
+      it 'returns the default version' do
+        expect(version.version).to eq(klass::DEFAULT_VERSION)
+        expect(version.epoch).to be nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Addresses #175.  `fpm` sets a default version -- `"1.0"` -- when invoked from the command line, but not when used as a library.  This PR updates `Package::Version` with the `DEFAULT_VERSION` constant, updated `#split_version`, and a `#version` accessor that guards against `nil`.