### PR TITLE
fix extracting zip files

### DIFF
--- a/lib/fpm/cookery/source_handler/curl.rb
+++ b/lib/fpm/cookery/source_handler/curl.rb
@@ -29,7 +29,7 @@ module FPM
               File.chmod(0755, local_path)
               safesystem(local_path)
             when '.zip'
-              safesystem('unzip', '-d', local_path.basename('.zip'), local_path)
+              safesystem('unzip', local_path)
             else
               if !local_path.directory? && !local_path.basename.exist?
                 Dir.mkdir(local_path.basename)


### PR DESCRIPTION
Extracting from a zip file creates an additional directory in the build dir hierarchy, while extracting from a tarball does not. This causes some builds from zip files to fail, which would have succeeded if the sources were packaged in a tarball.