### PR TITLE
Explicitly convert `recipe.to_json.lines` to an array in recipe spec

### DIFF
--- a/spec/recipe_spec.rb
+++ b/spec/recipe_spec.rb
@@ -630,7 +630,7 @@ describe "Recipe" do
     it "returns a terse JSON-formatted string with recipe attributes" do
       json = recipe.to_json
       expect { JSON.load(json) }.not_to raise_error
-      expect(json.lines.length).to be == 1
+      expect(json.lines.to_a.length).to be == 1
       expect(json).to match(/"name"/)
     end
   end
@@ -639,7 +639,7 @@ describe "Recipe" do
     it "returns a multiline JSON-formatted string with recipe attributes" do
       json = recipe.to_pretty_json
       expect { JSON.load(json) }.not_to raise_error
-      expect(json.lines.length).to be > 1
+      expect(json.lines.to_a.length).to be > 1
       expect(json).to match(/"name"/)
     end
   end


### PR DESCRIPTION
Fixes a bug introduced in #165 by yours truly.

Ruby 1.9's `String#lines` returns an `Enumerator`, unlike later Rubies where it returns an `Array`.  This PR updates `recipe_spec.rb`, calling `#to_a` to avoid a `NoMethodError` when running tests on pre-2.0 Rubies.