### PR TITLE
Add safe_yaml as a runtime dependency

### DIFF
--- a/fpm-cookery.gemspec
+++ b/fpm-cookery.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "systemu"
   s.add_runtime_dependency "json", ">= 1.7.7", "< 2.0"
   s.add_runtime_dependency "json_pure", ">= 1.7.7", "< 2.0"
+  s.add_runtime_dependency "safe_yaml", "~> 1.0.4"
 end


### PR DESCRIPTION
Adding `safe_yaml` as a runtime dependency fixes issue #154. Tested on Ubuntu 16.04 which has ruby 2.3 by default.

Found that `safe_yaml` was the required magic after stumbling on [this ticket](https://tickets.puppetlabs.com/browse/PUP-3796?focusedCommentId=310078&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-310078).