### PR TITLE
Give default value to config from facter

### DIFF
--- a/lib/fpm/cookery/cli.rb
+++ b/lib/fpm/cookery/cli.rb
@@ -59,17 +59,16 @@ module FPM
           end
 
           # Override the detected platform.
-          if platform
+          if platform.nil?
+            config.platform = FPM::Cookery::Facts.platform
+          else
             FPM::Cookery::Facts.platform = platform
           end
 
-          if target
+          if target.nil?
+            config.target = FPM::Cookery::Facts.target
+          else
             FPM::Cookery::Facts.target = target
-          end
-
-          if FPM::Cookery::Facts.target.nil?
-            Log.error "No target given and we're unable to detect your platform"
-            exit 1
           end
         end
 


### PR DESCRIPTION
This PR will fix the hiera hierarchy values in case the platform and/or the target is not set from the command line the thing that will prevent the documented lookup to function correctly.