### PR TITLE
Add rpm_dist method.

### DIFF
--- a/lib/fpm/cookery/package/package.rb
+++ b/lib/fpm/cookery/package/package.rb
@@ -33,6 +33,7 @@ module FPM
           @fpm.attributes[:rpm_group] = 'root'
           @fpm.attributes[:rpm_defattrfile] = '-'
           @fpm.attributes[:rpm_defattrdir] = '-'
+          @fpm.attributes[:rpm_dist] = recipe.rpm_dist.to_s if recipe.rpm_dist
           @fpm.attributes[:excludes] = recipe.exclude
 
           # Package type specific code should be called in package_setup.

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -31,7 +31,7 @@ module FPM
 
       extend FPM::Cookery::InheritableAttr
 
-      attr_rw :arch, :description, :homepage, :maintainer, :md5, :name,
+      attr_rw :arch, :description, :rpm_dist, :homepage, :maintainer, :md5, :name,
               :revision, :section, :sha1, :sha256, :spec, :vendor, :version,
               :pre_install, :post_install, :pre_uninstall, :post_uninstall,
               :license, :omnibus_package, :omnibus_dir, :chain_package,

--- a/spec/recipe_spec.rb
+++ b/spec/recipe_spec.rb
@@ -75,6 +75,12 @@ describe "Recipe" do
     expect(recipe.send(attr)).to eq(expect)
   end
 
+  describe '#rpm_dist' do
+    it 'can be set' do
+      check_attribute(:rpm_dist, 'el7')
+    end
+  end
+
   describe "#arch" do
     it "can be set" do
       check_attribute(:arch, 'i386')


### PR DESCRIPTION
Currently when building RPMs for many platforms, files are getting overwritten as no Distribution Tag is set, so the RPM file name does not contain distribution version like `el6` or `el7` which results in `foobar-version.rpm` file being build for all the distributions.

This change adds `rpm_dist` method to recipe file. This results in `:rpm_dist` attribute to be set in `FPM::Package::RPM` and the output RPM file will be named: `foobar-version.el7.rpm`, given `el7` is being set as content of `rpm_dist`.