### PR TITLE
add target(s) specific setting in recipe

### DIFF
--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -65,6 +65,10 @@ module FPM
           Array(archs).member?(FPM::Cookery::Facts.arch) and block_given? ? yield : false
         end
 
+        def targets(valid_targets)
+          Array(valid_targets).member?(FPM::Cookery::Facts.target) and block_given? ? yield : false
+        end
+
         def platform
           FPM::Cookery::Facts.platform
         end

--- a/spec/recipe_spec.rb
+++ b/spec/recipe_spec.rb
@@ -459,6 +459,67 @@ describe "Recipe" do
     end
   end
 
+  describe ".targets" do
+    before do
+      FPM::Cookery::Facts.class_eval do
+        class << self
+          alias_method :target_orig, :target
+          def target; :rpm; end
+        end
+      end
+    end
+
+    after do
+      FPM::Cookery::Facts.class_eval do
+        class << self
+          alias_method :target, :target_orig
+        end
+      end
+    end
+
+    describe "with a list of targets" do
+      it "allows target specific settings" do
+        recipe_klass.class_eval do
+          vendor 'a'
+
+          targets [:rpm, :deb] do
+            vendor 'b'
+          end
+        end
+
+        expect(recipe_klass.new.vendor).to eq('b')
+      end
+    end
+
+    describe "with a single target" do
+      it "allows target specific settings" do
+        recipe_klass.class_eval do
+          vendor 'a'
+
+          targets :rpm do
+            vendor 'b'
+          end
+        end
+
+        expect(recipe_klass.new.vendor).to eq('b')
+      end
+    end
+
+    describe "without a matching target" do
+      it "does not set target specific settings" do
+        recipe_klass.class_eval do
+          vendor 'a'
+
+          targets :deb do
+            vendor 'b'
+          end
+        end
+
+        expect(recipe_klass.new.vendor).to eq('a')
+      end
+    end
+  end
+
   describe ".platform" do
     it 'matches the current platform from FPM::Cookery::Facts' do
       expect(recipe_klass.platform).to eq(FPM::Cookery::Facts.platform)


### PR DESCRIPTION
Similar to `platforms` and `architectures`, allow adding a target(s) specific section on recipe.