### PR TITLE
Ensure :noop sources are always treated as fetchable

### DIFF
--- a/lib/fpm/cookery/packager.rb
+++ b/lib/fpm/cookery/packager.rb
@@ -174,7 +174,7 @@ module FPM
               end
             end #end chdir extracted_source
           end #end chdir builddir
-        end #end defined source_handler
+        end #end source_handler.fetchable?
 
         if skip_package?
           Log.info "Package building disabled"

--- a/lib/fpm/cookery/source_handler.rb
+++ b/lib/fpm/cookery/source_handler.rb
@@ -17,8 +17,7 @@ module FPM
       REQUIRED_METHODS = [:fetch, :extract]
 
       extend Forwardable
-      def_delegators :@handler, :fetch, :extract, :local_path, :checksum?
-      def_delegators :@source, :fetchable?
+      def_delegators :@handler, :fetch, :extract, :local_path, :checksum?, :fetchable?
 
       attr_reader :source_url
 

--- a/lib/fpm/cookery/source_handler/noop.rb
+++ b/lib/fpm/cookery/source_handler/noop.rb
@@ -15,6 +15,10 @@ module FPM
           Log.info "Not extracting - noop source handler"
           builddir.to_s
         end
+
+        def fetchable?
+          true
+        end
       end
     end
   end

--- a/lib/fpm/cookery/source_handler/template.rb
+++ b/lib/fpm/cookery/source_handler/template.rb
@@ -28,6 +28,10 @@ module FPM
           raise "#{self}#fetch not implemented!"
         end
 
+        def fetchable?
+          @url.fetchable?
+        end
+
         def extract(config = {})
           raise "#{self}#extract not implemented!"
         end

--- a/spec/source_handler_spec.rb
+++ b/spec/source_handler_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'fpm/cookery/source'
+require 'fpm/cookery/source_handler'
+
+describe 'SourceHandler' do
+  let(:cachedir) { FPM::Cookery::Path.new('/tmp/cache') }
+  let(:builddir) { FPM::Cookery::Path.new('/tmp/build') }
+
+  describe "#fetchable?" do
+    context "when using the noop source handler" do
+      it "always returns true" do
+        nil_source = FPM::Cookery::Source.new(nil, :with => :noop)
+        empty_source = FPM::Cookery::Source.new('', :with => :noop)
+
+        nil_handler = FPM::Cookery::SourceHandler.new(nil_source, cachedir, builddir)
+        empty_handler = FPM::Cookery::SourceHandler.new(empty_source, cachedir, builddir)
+
+        expect(nil_handler.fetchable?).to eq(true)
+        expect(empty_handler.fetchable?).to eq(true)
+      end
+    end
+
+    context "otherwise" do
+      it "returns true when the source URI is non-empty" do
+        fetchable_sources = [
+          ['https://somedomain.io/project-1.2-3.tar.xz'],
+          ['https://git.mysite.cat/atonic.git', :with => :git],
+          ['/var/src', :with => :directory],
+        ].map { |s| FPM::Cookery::Source.new(*s) }
+
+        unfetchable_sources = [
+          [''],
+          [nil, :with => :git],
+          ['', :with => :directory],
+        ].map { |s| FPM::Cookery::Source.new(*s) }
+
+        fetchable_handlers = fetchable_sources.map { |fs| FPM::Cookery::SourceHandler.new(fs, cachedir, builddir) }
+        unfetchable_handlers = unfetchable_sources.map { |us| FPM::Cookery::SourceHandler.new(us, cachedir, builddir) }
+
+        expect(fetchable_handlers.map(&:fetchable?)).to all(eq(true))
+        expect(unfetchable_handlers.map(&:fetchable?)).to all(eq(false))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Corrects an issue introduced by yours truly in [8a710db8](https://github.com/bernd/fpm-cookery/commit/8a710db8b3185c06b74d18af33a99cf93ce830b9#diff-c11b5d68a1ed6db28f1feba18f78009b).  The `:noop` source handler should be considered `:fetchable?` regardless of whether a non-nil, non-empty URI was provided as the first argument to the `Recipe#source` method.  Otherwise, [much of the recipe-building code](https://github.com/bernd/fpm-cookery/blob/1d80f16b97ef2d7bb20580a2d46baa57d1cb8aba/lib/fpm/cookery/packager.rb#L82-L177) won't run.