### PR TITLE
allow usage of newer (currently 5.5.x) puppet version

### DIFF
--- a/fpm-cookery.gemspec
+++ b/fpm-cookery.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov", "~> 0.11"
   s.add_runtime_dependency "fpm", "~> 1.1"
   s.add_runtime_dependency "facter"
-  s.add_runtime_dependency "puppet", "~> 3.4"
+  s.add_runtime_dependency "puppet", ">= 3.4", "< 6.0"
   s.add_runtime_dependency "addressable", "~> 2.3.8"
   s.add_runtime_dependency "systemu"
   s.add_runtime_dependency "json", ">= 1.7.7", "< 2.0"

--- a/lib/fpm/cookery/hiera.rb
+++ b/lib/fpm/cookery/hiera.rb
@@ -1,4 +1,5 @@
 require 'hiera'
+require 'hiera/version'
 require 'fpm/cookery/hiera/defaults'
 require 'fpm/cookery/hiera/scope'
 require 'fpm/cookery/log/hiera'
@@ -26,7 +27,10 @@ module FPM
         # Provides a default scope, and attempts to look up the key both as a
         # string and as a symbol.
         def lookup(key, default = nil, scope = self.scope, *rest)
-          super(key.to_sym, default, scope, *rest) || super(key.to_s, default, scope, *rest)
+          
+          (Gem::Version.new(::Hiera.version) < Gem::Version.new('2.0.0') &&
+               super(key.to_sym, default, scope, *rest)) ||
+            super(key.to_s, default, scope, *rest)
         end
         alias_method :[], :lookup
       end

--- a/lib/fpm/cookery/hiera/scope.rb
+++ b/lib/fpm/cookery/hiera/scope.rb
@@ -29,6 +29,16 @@ module FPM
             result.value
           end
         end
+
+        # Newer versions of Hiera requires also +#include?+ method for context
+        def include?(name)
+          [recipe, FPM::Cookery::Facts].each do |source|
+            return true if source.respond_to?(name)
+          end
+
+          # If not found, check in +Facter+.
+          ! Facter[name].nil?
+        end
       end
     end
   end


### PR DESCRIPTION
(First of all - I found fpm-cookery (along with fpm) very great piece of software and I hope it will ease my headache "how to build custom rpm/deb for ~15 different linux platforms".)

Currently fpm-cookery has very conservative restriction for puppet version (~>3.4), which means 3.8.x and nothing more ever - as 3.x line is dead.
That old puppet suffers from several problems on newer environments (e.g. https://tickets.puppetlabs.com/browse/PUP-7383, but I also encountered others), resolving them means ugly (mokey-)patching of puppet every time :(

As i checked, ftp-cookery has no problem using latest currently available puppets (5.5.x), there are only minor problems with newer hiera (which is pulled as new puppet's dependency).

So what I am proposing here:
1. relax puppet version requirement to >=3.4, <6.0 (seems to be safe now)
2. apply fixes needed by hiera >= 2:
- add #include? method in FPM::Cookery::Hiera::Scope (hiera calls it now despite docs says nothing about it...)
- in FPM::Cookery::Hiera::Instance#lookup for newer hiera (>=2.0.0) don't call lookup with symbol as key value. Hiera currently expects only String there (as docs says) and passing symbol triggers errors from inside of hiera code. I don't fully understand reason for dual "symbol/String" lookup call from FPM::Cookery::Hiera::Instance#lookup - so I left dual version for old (<2.0.0) hieras and "String only" for newer (>=2.0.0) based on detected hiera version.

(All changes in PR works for my packages and passes all tests in fpm-cookery)
