### PR TITLE
Add sha512 checksum support

### DIFF
--- a/lib/fpm/cookery/packager.rb
+++ b/lib/fpm/cookery/packager.rb
@@ -90,7 +90,7 @@ module FPM
             if source.checksum?
               SourceIntegrityCheck.new(recipe).tap do |check|
                 if check.checksum_missing?
-                  Log.warn 'Recipe does not provide a checksum. (sha256, sha1 or md5)'
+                  Log.warn 'Recipe does not provide a checksum. (sha512, sha256, sha1 or md5)'
                   Log.puts <<-__WARN
   Digest:   #{check.digest}
   Checksum: #{check.checksum_actual}

--- a/lib/fpm/cookery/recipe.rb
+++ b/lib/fpm/cookery/recipe.rb
@@ -32,7 +32,7 @@ module FPM
       extend FPM::Cookery::InheritableAttr
 
       attr_rw :arch, :description, :rpm_dist, :homepage, :maintainer, :md5, :name,
-              :revision, :section, :sha1, :sha256, :spec, :vendor, :version,
+              :revision, :section, :sha1, :sha256, :sha512, :spec, :vendor, :version,
               :pre_install, :post_install, :pre_uninstall, :post_uninstall,
               :license, :omnibus_package, :omnibus_dir, :chain_package,
               :default_prefix

--- a/lib/fpm/cookery/source_integrity_check.rb
+++ b/lib/fpm/cookery/source_integrity_check.rb
@@ -43,7 +43,7 @@ module FPM
       end
 
       def get_checksum
-        type = [:sha256, :sha1, :md5].find do |digest|
+        type = [:sha512, :sha256, :sha1, :md5].find do |digest|
           @recipe.respond_to?(digest) and
           @recipe.send(digest) and
           !@recipe.send(digest).empty?

--- a/recipes/activemq/recipe.rb
+++ b/recipes/activemq/recipe.rb
@@ -1,0 +1,15 @@
+class ActiveMQ < FPM::Cookery::Recipe
+  name 'apache-activemq'
+  version '5.15.6'
+  url 'http://archive.apache.org/dist/activemq/5.15.6/apache-activemq-5.15.6-bin.tar.gz'
+  # Checksum from http://archive.apache.org/dist/activemq/5.15.6/apache-activemq-5.15.6-bin.tar.gz.sha512
+  sha512 'a1b931a25c513f83f4f712cc126ee67a2b196ea23a243aa6cafe357ea03f721fba6cb566701e5c0e1f2f7ad8954807361364635c45d5069ec2dbf0ba5c6b588b'
+
+  def build
+  end
+
+  def install
+    opt.install Dir["#{builddir}/*"]
+  end
+
+end

--- a/spec/recipe_spec.rb
+++ b/spec/recipe_spec.rb
@@ -111,6 +111,12 @@ describe "Recipe" do
     end
   end
 
+  describe "#sha512" do
+    it "can be set" do
+      check_attribute(:sha512, '123456789abcdef')
+    end
+  end
+
   describe "#sha256" do
     it "can be set" do
       check_attribute(:sha256, '123456789abcdef')

--- a/spec/source_integrity_check_spec.rb
+++ b/spec/source_integrity_check_spec.rb
@@ -48,6 +48,44 @@ describe "SourceIntegrityCheck" do
     end
   end
 
+  describe "with a correct sha512 checksum defined" do
+    describe "#error?" do
+      it "returns false" do
+        allow(recipe).to receive(:sha512).and_return('488f02db910d6a12f194ed62d7e6a89d9e408c8354acb875cf81c5fb284022cd320d4803a968f8754f5cc53797d515994619f669d359e3b4f989801a39ee6ffd')
+
+        expect(check.error?).to eq(false)
+      end
+    end
+  end
+
+  describe "with a wrong sha512 checksum defined" do
+    before do
+      allow(recipe).to receive(:sha512).and_return('xxxx02db910d6a12f194ed62d7e6a89d9e408c8354acb875cf81c5fb284022cd320d4803a968f8754f5cc53797d515994619f669d359e3b4f989801a39ee6ffd')
+    end
+
+    describe "#error?" do
+      it "returns true" do
+        expect(check.error?).to eq(true)
+      end
+    end
+
+    it "has checksum_expected set to the expected checksum" do
+      expect(check.checksum_expected).to eq('xxxx02db910d6a12f194ed62d7e6a89d9e408c8354acb875cf81c5fb284022cd320d4803a968f8754f5cc53797d515994619f669d359e3b4f989801a39ee6ffd')
+    end
+
+    it "has checksum_actual set to the actual checksum" do
+      expect(check.checksum_actual).to eq('488f02db910d6a12f194ed62d7e6a89d9e408c8354acb875cf81c5fb284022cd320d4803a968f8754f5cc53797d515994619f669d359e3b4f989801a39ee6ffd')
+    end
+
+    it "has filename set" do
+      expect(check.filename).to eq(fixture_path('test-source-1.0.tar.gz'))
+    end
+
+    it "has digest set to :sha512" do
+      expect(check.digest).to eq(:sha512)
+    end
+  end
+
   describe "with a correct sha256 checksum defined" do
     describe "#error?" do
       it "returns false" do


### PR DESCRIPTION
Ruby stdlib already knows how to deal with sha512, so
just enable fpm-cook to recognize the keyword.

Copied existing tests for sha256 and updated appropriately

Include simple Apache ActiveMQ recipe. ActiveMQ's downloads
only provide sha512 checksums, so seemed a reasonable example.
Recipe simply grabs Apache's binary distro and drops it in /opt