### PR TITLE
Fixes for newer Rubies

### DIFF
--- a/fpm-cookery.gemspec
+++ b/fpm-cookery.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"
   s.add_development_dependency "simplecov", "~> 0.11"
+
   s.add_runtime_dependency "fpm", "~> 1.1"
   s.add_runtime_dependency "facter"
   s.add_runtime_dependency "puppet", "~> 3.4"
@@ -30,4 +31,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "json", ">= 1.7.7", "< 2.0"
   s.add_runtime_dependency "json_pure", ">= 1.7.7", "< 2.0"
   s.add_runtime_dependency "safe_yaml", "~> 1.0.4"
+
+  # xmlrpc, which is a dependency of puppet, was removed from Ruby in 2.4.0
+  if RUBY_VERSION >= "2.4.0"
+    s.add_runtime_dependency "xmlrpc", "~> 0.3.0"
+  end
 end

--- a/lib/fpm/cookery/dependency_inspector.rb
+++ b/lib/fpm/cookery/dependency_inspector.rb
@@ -1,5 +1,6 @@
 require 'fpm/cookery/facts'
 require 'fpm/cookery/log'
+require 'fpm/cookery/monkey_patches'
 
 begin
   require 'puppet'

--- a/lib/fpm/cookery/monkey_patches.rb
+++ b/lib/fpm/cookery/monkey_patches.rb
@@ -1,0 +1,15 @@
+module FPM
+  module Cookery
+    class MonkeyPatches
+      require 'openssl'
+      # On newer systems running openssl 1.1 or greater, DEFAULT_PARAMS[:ciphers]
+      # isn't set, so we need this conditional block otherwise puppet will abort
+      # with an `undefined method` error
+      class OpenSSL::SSL::SSLContext
+        if DEFAULT_PARAMS[:ciphers]
+          DEFAULT_PARAMS[:ciphers] << ':!SSLv2'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Two fixes to get fpm-cookery working on newer systems:
* Add `xmlrpc` as a dependency on systems running ruby 2.4.0 or greater (it was previously in the stdlib but has since been removed, and puppet requires it)
* Monkey patch `OpenSSL::SSL::SSLContext` with an if block when attempting to set `DEFAULT_PARAMS[:ciphers]`, otherwise puppet will error out with an `undefined method` error. More info in [PUP-7383](https://tickets.puppetlabs.com/browse/PUP-7383).

I've tested this out on the following systems with their distro rubies:
* Ubuntu 18.04: ruby 2.5.1p57
* Ubuntu 16.04: ruby 2.3.1p112
* Ubuntu 14.04: ruby 1.9.3p484