### PR TITLE
patch: automatically gunzip gzipped patch files

### DIFF
--- a/lib/fpm/cookery/utils.rb
+++ b/lib/fpm/cookery/utils.rb
@@ -83,7 +83,12 @@ module FPM
       def patch(src, level = 0)
         raise "patch level must be integer" unless level.is_a?(Fixnum)
         raise "#{src} does not exist" unless File.exist? src
-        safesystem "patch -p#{level} --batch < #{src}"
+
+        if "#{src}".end_with?('.gz')
+          safesystem "gunzip -c #{src} | patch -p#{level} --batch"
+        else
+          safesystem "patch -p#{level} --batch < #{src}"
+        end
       end
     end
   end


### PR DESCRIPTION
I'm increasingly building recipes with rather large patch files which I'm having to gzip. Instead of continually adding a `safesystem()` call to heaps of my recipes to decompress the gzipped patch files, I thought it'd be easier if fpm-cookery did it for me...

I considered using [ruby-filemagic](http://github.com/blackwinter/ruby-filemagic) to detect the filetype but I didn't want to introduce another dependancy for such a small feature.

Lemme know if this :+1: :-1:

Thanks.