### PR TITLE
Add a golang util

### DIFF
--- a/lib/fpm/cookery/utils.rb
+++ b/lib/fpm/cookery/utils.rb
@@ -6,8 +6,13 @@ module FPM
       protected
       # From fpm. (lib/fpm/util.rb)
       def safesystem(*args)
-        # Make sure to avoid nil elements in args. This might happen on 1.8.
-        success = system(*args.compact.flatten)
+        # Process the arguments:
+        #   - Convert all arguments to strings because "system" cannot handle
+        #     keys (avoids TypeError)
+        #   - Make sure to avoid nil elements in args. This might happen on 1.8.
+        safe_args = args.map(&:to_s).compact.flatten
+        Log.debug("Executing command: #{safe_args.inspect}")
+        success = system(*safe_args)
         if !success
           raise "'system(#{args.inspect})' failed with error code: #{$?.exitstatus}"
         end
@@ -94,7 +99,7 @@ module FPM
       def go(*args)
         args = argument_build(*args)
         args.each {|a| a == '--mod=vendor' && ENV['GO111MODULE'] = 'on' }
-        safesystem "go #{args.join(' ')}"
+        safesystem 'go', *args
       end
     end
   end

--- a/lib/fpm/cookery/utils.rb
+++ b/lib/fpm/cookery/utils.rb
@@ -90,6 +90,12 @@ module FPM
           safesystem "patch -p#{level} --batch < #{src}"
         end
       end
+
+      def go(*args)
+        args = argument_build(*args)
+        args.each {|a| a == '--mod=vendor' && ENV['GO111MODULE'] = 'on' }
+        safesystem "go #{args.join(' ')}"
+      end
     end
   end
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -20,6 +20,14 @@ describe FPM::Cookery::Utils do
     def run_configure_mix
       configure '--first=okay', '--second=okay', :hello_world => true, :prefix => '/usr', 'a-dash' => 1
     end
+
+    def run_go_build
+      go 'build', '-mod=vendor', '-v'
+    end
+
+    def run_go_build_hash
+      go :build, :mod => 'vendor', :v => true
+    end
   end
 
   let(:test) { TestUtils.new }
@@ -55,6 +63,21 @@ describe FPM::Cookery::Utils do
       it 'calls ./configure without any arguments' do
         expect(test).to receive(:system).with('./configure')
         test.run_configure_no_arg
+      end
+    end
+  end
+  describe '#go' do
+    context 'with a list of string arguments' do
+      it 'calls go with the correct arguments' do
+        expect(test).to receive(:system).with('go', 'build', '-mod=vendor', '-v')
+        test.run_go_build
+      end
+    end
+
+    context 'with hash arguments' do
+      it 'calls go with the correct arguments' do
+        expect(test).to receive(:system).with('go', 'build', '--mod=vendor', '--v')
+        test.run_go_build_hash
       end
     end
   end


### PR DESCRIPTION
A util function for [`go`](https://golang.org/cmd/go/) commands such as `go build`, eg:

```
def build
  go :mod, :verify
  go :build, :mod => 'vendor', :v => true
```

