### PR TITLE
allowing newer version of puppet

### DIFF
--- a/fpm-cookery.gemspec
+++ b/fpm-cookery.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov", "~> 0.11"
   s.add_runtime_dependency "fpm", "~> 1.1"
   s.add_runtime_dependency "facter"
-  s.add_runtime_dependency "puppet", ">= 3.4", "< 6.0"
+  s.add_runtime_dependency "puppet", ">= 3.4", "< 7.0"
   s.add_runtime_dependency "addressable", "~> 2.3.8"
   s.add_runtime_dependency "systemu"
   s.add_runtime_dependency "json", ">= 1.7.7", "< 2.0"


### PR DESCRIPTION
I am starting to build packages for Ubuntu 20 (Focal Fossa). Puppet does [not seem to support ](https://tickets.puppetlabs.com/browse/PA-3127) Ubuntu 20 with version 5 and below. This change allows Puppet 6 to be installed.

Error on Ubuntu 20:
```
/var/lib/gems/2.7.0/gems/puppet-5.5.20/lib/puppet/resource/catalog.rb:232:in `apply': uninitialized constant Puppet::Util::Storage (NameError)
	from /var/lib/gems/2.7.0/gems/puppet-5.5.20/lib/puppet/indirector/resource/ral.rb:38:in `save'
	from /var/lib/gems/2.7.0/gems/puppet-5.5.20/lib/puppet/indirector/indirection.rb:289:in `save'
	from /var/lib/gems/2.7.0/gems/fpm-cookery-0.35.1/lib/fpm/cookery/dependency_inspector.rb:59:in `package_installed?'
```

Thoughts on bumping this gem? Tests appear to work and packages are building on Ubuntu 20