### PR TITLE
Replace call deprecated to File.exists? with File.exist?

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.4", "2.5", "2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
 
     steps:
     - uses: actions/checkout@v1

--- a/lib/fpm/cookery/chain_packager.rb
+++ b/lib/fpm/cookery/chain_packager.rb
@@ -20,7 +20,7 @@ module FPM
         DependencyInspector.verify!([], recipe.build_depends)
         recipe.chain_recipes.each do |name|
           recipe_file = build_recipe_file_path(name)
-          unless File.exists?(recipe_file)
+          unless File.exist?(recipe_file)
             error_message = "Cannot find a recipe for #{name} at #{recipe_file}"
             Log.fatal error_message
             raise Error::ExecutionFailure, error_message
@@ -49,7 +49,7 @@ module FPM
         recipe.chain_recipes.each do |name|
           recipe_file = build_recipe_file_path(name)
 
-          unless File.exists?(recipe_file)
+          unless File.exist?(recipe_file)
             Log.fatal "Cannot find a recipe for #{name} at #{recipe_file}"
             exit 1
           end

--- a/lib/fpm/cookery/cli.rb
+++ b/lib/fpm/cookery/cli.rb
@@ -60,7 +60,7 @@ module FPM
           file = File.expand_path(recipe)
 
           # Allow giving the directory containing a recipe.rb
-          if File.directory?(file) && File.exists?(File.join(file, 'recipe.rb'))
+          if File.directory?(file) && File.exist?(File.join(file, 'recipe.rb'))
             file = File.join(file, 'recipe.rb')
           end
 
@@ -68,7 +68,7 @@ module FPM
         end
 
         def validate
-          unless File.exists?(recipe_file)
+          unless File.exist?(recipe_file)
             Log.error 'No recipe.rb found in the current directory, abort.'
             exit 1
           end

--- a/lib/fpm/cookery/omnibus_packager.rb
+++ b/lib/fpm/cookery/omnibus_packager.rb
@@ -21,7 +21,7 @@ module FPM
         _recipe.omnibus_recipes.each do |name|
           recipe_file = build_recipe_file_path(name)
           Log.info "Loading dependency recipe #{name} from #{recipe_file}"
-          unless File.exists?(recipe_file)
+          unless File.exist?(recipe_file)
             error_message = "Cannot find a recipe for #{name} at #{recipe_file}"
             Log.fatal error_message
             raise Error::ExecutionFailure, error_message

--- a/lib/fpm/cookery/packager.rb
+++ b/lib/fpm/cookery/packager.rb
@@ -119,7 +119,7 @@ module FPM
 
             # Do not extract source again because it might destroy changes
             # that have been made to the source. (like patches)
-            if File.exists?(extract_cookie)
+            if File.exist?(extract_cookie)
               extracted_source = File.read(extract_cookie).chomp
               Log.debug "Extract cookie exists, using existing source directory: #{extracted_source}"
             else
@@ -149,7 +149,7 @@ module FPM
 
               build_cookie = build_cookie_name(package_name)
 
-              if File.exists?(build_cookie)
+              if File.exist?(build_cookie)
                 Log.warn "Skipping build of #{recipe.name} because build cookie found (#{build_cookie})," \
                          " use \"fpm-cook clean\" to rebuild!"
               else
@@ -161,7 +161,7 @@ module FPM
               end
 
               FileUtils.rm_rf(recipe.destdir) unless keep_destdir?
-              recipe.destdir.mkdir unless File.exists?(recipe.destdir)
+              recipe.destdir.mkdir unless File.exist?(recipe.destdir)
 
               begin
                 recipe.installing = true
@@ -243,7 +243,7 @@ module FPM
               script_file = File.expand_path("../#{script_file.to_s}", recipe.filename)
             end
 
-            if File.exists?(script_file)
+            if File.exist?(script_file)
               input.add_script(script, File.read(script_file.to_s))
             else
               Log.error "#{script} script '#{script_file}' is missing"

--- a/spec/path_spec.rb
+++ b/spec/path_spec.rb
@@ -91,10 +91,10 @@ describe "Path" do
     it "creates the directory" do
       dir = Dir.mktmpdir
       FileUtils.rm_rf(dir)
-      expect(File.exists?(dir)).to eq(false)
+      expect(File.exist?(dir)).to eq(false)
 
       FPM::Cookery::Path.new(dir).mkdir
-      expect(File.exists?(dir)).to eq(true)
+      expect(File.exist?(dir)).to eq(true)
 
       FileUtils.rm_rf(dir)
     end
@@ -102,7 +102,7 @@ describe "Path" do
     describe "directory exists" do
       it "does not throw an error" do
         dir = Dir.mktmpdir
-        expect(File.exists?(dir)).to eq(true)
+        expect(File.exist?(dir)).to eq(true)
 
         expect(FPM::Cookery::Path.new(dir).mkdir).to eq([dir])
 


### PR DESCRIPTION
File.exists? was removed in Ruby 3.2.x