### PR TITLE
Remove support for hiera versions < 2.0.0

### DIFF
--- a/lib/fpm/cookery/hiera.rb
+++ b/lib/fpm/cookery/hiera.rb
@@ -27,9 +27,6 @@ module FPM
         # Provides a default scope, and attempts to look up the key both as a
         # string and as a symbol.
         def lookup(key, default = nil, scope = self.scope, *rest)
-          
-          (Gem::Version.new(::Hiera.version) < Gem::Version.new('2.0.0') &&
-               super(key.to_sym, default, scope, *rest)) ||
             super(key.to_s, default, scope, *rest)
         end
         alias_method :[], :lookup


### PR DESCRIPTION
This avoids a `File.exists?` call and makes it run on Ruby 3.2.